### PR TITLE
remove desktop code paths: drop MKXPZ_MINIFFI and desktop source entries

### DIFF
--- a/ios/Empo/project.yml
+++ b/ios/Empo/project.yml
@@ -47,7 +47,6 @@ settings:
     GCC_PREPROCESSOR_DEFINITIONS:
       - MKXPZ_BUILD_XCODE
       - MKXPZ_ALCDEVICE=ALCdevice_struct
-      - MKXPZ_MINIFFI
       - 'MKXPZ_VERSION="\"1.0.0\""'
       - 'MKXPZ_GIT_HASH="\"ios\""'
       - 'MKXPZ_RUBY_VERSION="\"3.1\""'
@@ -126,14 +125,9 @@ targets:
       - path: ../../mkxp-z-apple-mobile/src/eventthread.cpp
       - path: ../../mkxp-z-apple-mobile/src/sharedstate.cpp
       - path: ../../mkxp-z-apple-mobile/src/config.cpp
-      - path: ../../mkxp-z-apple-mobile/src/settingsmenu.cpp
       - path: ../../mkxp-z-apple-mobile/src/crypto/rgssad.cpp
       - path: ../../mkxp-z-apple-mobile/src/util/iniconfig.cpp
-      - path: ../../mkxp-z-apple-mobile/src/system/systemImpl.cpp
-        buildPhase: none
       - path: ../../mkxp-z-apple-mobile/src/filesystem/filesystem.cpp
-      - path: ../../mkxp-z-apple-mobile/src/filesystem/filesystemImpl.cpp
-        buildPhase: none
       - path: ../../mkxp-z-apple-mobile/src/input/input.cpp
       - path: ../../mkxp-z-apple-mobile/src/input/keybindings.cpp
       - path: ../../mkxp-z-apple-mobile/src/audio/audio.cpp
@@ -192,10 +186,7 @@ targets:
       - path: ../../mkxp-z-apple-mobile/binding/audio-binding.cpp
       - path: ../../mkxp-z-apple-mobile/binding/graphics-binding.cpp
       - path: ../../mkxp-z-apple-mobile/binding/filesystem-binding.cpp
-      - path: ../../mkxp-z-apple-mobile/binding/miniffi.cpp
-      - path: ../../mkxp-z-apple-mobile/binding/miniffi-binding.cpp
       - path: ../../mkxp-z-apple-mobile/binding/http-binding.cpp
-      - path: ../../mkxp-z-apple-mobile/binding/cusl-binding.cpp
       - path: ../../mkxp-z-apple-mobile/binding/module_rpg.cpp
       - path: ../../mkxp-z-apple-mobile/src/app_bridge.cpp
       - path: ../../mkxp-z-apple-mobile/src/angle_native_layer.mm


### PR DESCRIPTION
Paired with engine PR: mateo-m/mkxp-z-apple-mobile#4

Companion to the engine's remove-desktop change. Strips references to the deleted engine source files from project.yml and bumps the submodule pointer.

Replaces auto-closed PR #4 (closed when its base branch refactor/engine-host was deleted after PR #5 merged). Rebased as a single squashed commit onto main.

## Changes

- Removes MKXPZ_MINIFFI from GCC_PREPROCESSOR_DEFINITIONS
- Removes references to deleted engine files: settingsmenu.cpp, systemImpl.cpp, filesystemImpl.cpp, miniffi.cpp, miniffi-binding.cpp, cusl-binding.cpp
- Engine submodule pointer bumped to c846b49 (tip of engine remove-desktop)

## Tested

- Simulator and device builds succeed
- App launches without crashing