### PR TITLE
fix: pin player glass controls to dark color scheme

### DIFF
--- a/ios/Empo/src/Player/GameControls.swift
+++ b/ios/Empo/src/Player/GameControls.swift
@@ -54,6 +54,11 @@ struct ActionButton: View {
         .frame(width: size, height: size)
         .scaleEffect(isPressed ? 0.95 : 1.0)
         .animation(.spring(response: 0.2, dampingFraction: 0.7), value: isPressed)
+        // Force the dark Liquid Glass variant to match the D-pad.
+        // Both controls pin to `.dark` so the glass material looks
+        // consistent regardless of the system interface style or
+        // the brightness of the game content behind them.
+        .environment(\.colorScheme, .dark)
         .contentShape(Circle())
         // Touch dispatch. minimumDistance=0 makes this a press-tracking
         // gesture that fires on touch-down (not after a drag threshold).
@@ -208,6 +213,16 @@ struct DPad: View {
         // the plus silhouette.
         .scaleEffect(pressed ? 0.96 : 1.0)
         .animation(.spring(response: 0.2, dampingFraction: 0.7), value: pressed)
+        // Force the dark Liquid Glass variant so the plus clip shape
+        // doesn't render noticeably brighter than the action buttons'
+        // circles. With the default (system) color scheme, iOS 26's
+        // glass material resolves differently on a concave clip (our
+        // plus) than on a convex clip (our action-button circles),
+        // which showed up in dark gameplay scenes as a near-white
+        // D-pad next to translucent-dark action buttons. Pinning to
+        // .dark here locks the material in one mode and keeps the
+        // two visually consistent.
+        .environment(\.colorScheme, .dark)
         // Hit-test the full bounding circle so slightly imprecise
         // presses (between arms, just outside the plus shape) still
         // engage. The wedge math in updateDirections decides which

--- a/ios/Empo/src/Player/PlayerView.swift
+++ b/ios/Empo/src/Player/PlayerView.swift
@@ -356,6 +356,11 @@ struct PlayerView: View {
                 .accessibilityLabel(entry.label)
             }
         }
+        // Pin the Liquid Glass material to the dark variant so the
+        // toolbar matches the on-screen controls (D-pad, action
+        // buttons) and doesn't shift appearance with the system
+        // color scheme or the backdrop brightness of the game.
+        .environment(\.colorScheme, .dark)
         .opacity(toolbarOpacity)
         .position(toolbarPosition)
     }


### PR DESCRIPTION
iOS 26's Liquid Glass material resolves differently on concave clip shapes (the D-pad plus) vs convex shapes (the action-button circles and toolbar icons). On a dark gameplay backdrop this surfaced as a near-white D-pad next to translucent-dark action buttons and toolbar - visually jarring.

Fix: pin `\.colorScheme` to `.dark` on all three control groups (D-pad, action buttons, player toolbar) so the glass material renders consistently regardless of system interface style or game-backdrop brightness.

## Tested

- Sim + device builds clean
- All three control groups now render the same translucent-dark glass tone on dark and light gameplay content