### PR TITLE
refactor: centralize UserDefaults keys

### DIFF
--- a/ios/Empo/src/App/AppSettings.swift
+++ b/ios/Empo/src/App/AppSettings.swift
@@ -115,16 +115,16 @@ class AppSettings {
     static let shared = AppSettings()
 
     var theme: AppTheme {
-        didSet { UserDefaults.standard.set(theme.rawValue, forKey: "theme") }
+        didSet { UserDefaults.standard.set(theme.rawValue, forKey: DefaultsKey.theme) }
     }
 
     var debugMode: Bool {
-        didSet { UserDefaults.standard.set(debugMode, forKey: "debugMode") }
+        didSet { UserDefaults.standard.set(debugMode, forKey: DefaultsKey.debugMode) }
     }
 
     var showViewportBounds: Bool {
         didSet {
-            UserDefaults.standard.set(showViewportBounds, forKey: "showViewportBounds")
+            UserDefaults.standard.set(showViewportBounds, forKey: DefaultsKey.showViewportBounds)
             mkxp_setShowViewportBounds(showViewportBounds)
         }
     }
@@ -137,39 +137,39 @@ class AppSettings {
     }
 
     var debugLogs: Bool {
-        didSet { UserDefaults.standard.set(debugLogs, forKey: "debugLogs") }
+        didSet { UserDefaults.standard.set(debugLogs, forKey: DefaultsKey.debugLogs) }
     }
 
     var maxLogFiles: Int {
-        didSet { UserDefaults.standard.set(maxLogFiles, forKey: "maxLogFiles") }
+        didSet { UserDefaults.standard.set(maxLogFiles, forKey: DefaultsKey.maxLogFiles) }
     }
 
     var cleanupInvalidGames: Bool {
-        didSet { UserDefaults.standard.set(cleanupInvalidGames, forKey: "cleanupInvalidGames") }
+        didSet { UserDefaults.standard.set(cleanupInvalidGames, forKey: DefaultsKey.cleanupInvalidGames) }
     }
 
     var interfaceHaptics: Bool {
-        didSet { UserDefaults.standard.set(interfaceHaptics, forKey: "interfaceHaptics") }
+        didSet { UserDefaults.standard.set(interfaceHaptics, forKey: DefaultsKey.interfaceHaptics) }
     }
 
     var controllerHaptics: Bool {
-        didSet { UserDefaults.standard.set(controllerHaptics, forKey: "controllerHaptics") }
+        didSet { UserDefaults.standard.set(controllerHaptics, forKey: DefaultsKey.controllerHaptics) }
     }
 
     var titlePosition: TitlePosition {
-        didSet { UserDefaults.standard.set(titlePosition.rawValue, forKey: "titlePosition") }
+        didSet { UserDefaults.standard.set(titlePosition.rawValue, forKey: DefaultsKey.titlePosition) }
     }
 
     var libraryDisplayMode: LibraryDisplayMode {
-        didSet { UserDefaults.standard.set(libraryDisplayMode.rawValue, forKey: "libraryDisplayMode") }
+        didSet { UserDefaults.standard.set(libraryDisplayMode.rawValue, forKey: DefaultsKey.libraryDisplayMode) }
     }
 
     var showContinuePlaying: Bool {
-        didSet { UserDefaults.standard.set(showContinuePlaying, forKey: "showContinuePlaying") }
+        didSet { UserDefaults.standard.set(showContinuePlaying, forKey: DefaultsKey.showContinuePlaying) }
     }
 
     var librarySortOption: LibrarySortOption {
-        didSet { UserDefaults.standard.set(librarySortOption.rawValue, forKey: "librarySortOption") }
+        didSet { UserDefaults.standard.set(librarySortOption.rawValue, forKey: DefaultsKey.librarySortOption) }
     }
 
     // MARK: - Splash disclaimer acknowledgment
@@ -179,7 +179,7 @@ class AppSettings {
     static let currentDisclaimerVersion = 1
 
     var disclaimerAcknowledgedVersion: Int {
-        didSet { UserDefaults.standard.set(disclaimerAcknowledgedVersion, forKey: "disclaimerAcknowledgedVersion") }
+        didSet { UserDefaults.standard.set(disclaimerAcknowledgedVersion, forKey: DefaultsKey.disclaimerAcknowledgedVersion) }
     }
 
     var needsDisclaimer: Bool {
@@ -199,30 +199,31 @@ class AppSettings {
     }
 
     private init() {
-        let themeRaw = UserDefaults.standard.string(forKey: "theme") ?? AppTheme.auto.rawValue
+        let ud = UserDefaults.standard
+        let themeRaw = ud.string(forKey: DefaultsKey.theme) ?? AppTheme.auto.rawValue
         self.theme = AppTheme(rawValue: themeRaw) ?? .auto
-        self.debugMode = UserDefaults.standard.bool(forKey: "debugMode")
-        self.showViewportBounds = UserDefaults.standard.bool(forKey: "showViewportBounds")
+        self.debugMode = ud.bool(forKey: DefaultsKey.debugMode)
+        self.showViewportBounds = ud.bool(forKey: DefaultsKey.showViewportBounds)
         self.viewportBoundsColor = Self.loadViewportBoundsColor()
-        self.debugLogs = (UserDefaults.standard.object(forKey: "debugLogs") as? Bool) ?? true
-        let storedMax = UserDefaults.standard.integer(forKey: "maxLogFiles")
+        self.debugLogs = (ud.object(forKey: DefaultsKey.debugLogs) as? Bool) ?? true
+        let storedMax = ud.integer(forKey: DefaultsKey.maxLogFiles)
         self.maxLogFiles = storedMax > 0 ? storedMax : 20
-        self.cleanupInvalidGames = UserDefaults.standard.bool(forKey: "cleanupInvalidGames")
-        // Haptics default to on — UserDefaults.bool returns false for unset keys
-        self.interfaceHaptics = UserDefaults.standard.object(forKey: "interfaceHaptics") as? Bool ?? true
-        self.controllerHaptics = UserDefaults.standard.object(forKey: "controllerHaptics") as? Bool ?? true
-        let raw = UserDefaults.standard.string(forKey: "titlePosition") ?? TitlePosition.inside.rawValue
+        self.cleanupInvalidGames = ud.bool(forKey: DefaultsKey.cleanupInvalidGames)
+        // Haptics default to on - UserDefaults.bool returns false for unset keys
+        self.interfaceHaptics = ud.object(forKey: DefaultsKey.interfaceHaptics) as? Bool ?? true
+        self.controllerHaptics = ud.object(forKey: DefaultsKey.controllerHaptics) as? Bool ?? true
+        let raw = ud.string(forKey: DefaultsKey.titlePosition) ?? TitlePosition.inside.rawValue
         self.titlePosition = TitlePosition(rawValue: raw) ?? .inside
-        let modeRaw = UserDefaults.standard.string(forKey: "libraryDisplayMode") ?? LibraryDisplayMode.grid.rawValue
+        let modeRaw = ud.string(forKey: DefaultsKey.libraryDisplayMode) ?? LibraryDisplayMode.grid.rawValue
         self.libraryDisplayMode = LibraryDisplayMode(rawValue: modeRaw) ?? .grid
-        self.showContinuePlaying = UserDefaults.standard.object(forKey: "showContinuePlaying") as? Bool ?? true
-        let sortRaw = UserDefaults.standard.string(forKey: "librarySortOption") ?? LibrarySortOption.titleAZ.rawValue
+        self.showContinuePlaying = ud.object(forKey: DefaultsKey.showContinuePlaying) as? Bool ?? true
+        let sortRaw = ud.string(forKey: DefaultsKey.librarySortOption) ?? LibrarySortOption.titleAZ.rawValue
         self.librarySortOption = LibrarySortOption(rawValue: sortRaw) ?? .titleAZ
-        self.disclaimerAcknowledgedVersion = UserDefaults.standard.integer(forKey: "disclaimerAcknowledgedVersion")
+        self.disclaimerAcknowledgedVersion = ud.integer(forKey: DefaultsKey.disclaimerAcknowledgedVersion)
 
         var flags: [String: Bool] = [:]
         for feature in ExperimentalFeature.allCases {
-            flags[feature.rawValue] = UserDefaults.standard.bool(forKey: feature.rawValue)
+            flags[feature.rawValue] = ud.bool(forKey: feature.rawValue)
         }
         self.experimentalFlags = flags
 
@@ -244,13 +245,13 @@ class AppSettings {
 
     private static func loadViewportBoundsColor() -> Color {
         let ud = UserDefaults.standard
-        guard ud.object(forKey: "vpBoundsR") != nil else { return defaultViewportBoundsColor }
+        guard ud.object(forKey: DefaultsKey.viewportBoundsR) != nil else { return defaultViewportBoundsColor }
         return Color(
             .sRGB,
-            red: ud.double(forKey: "vpBoundsR"),
-            green: ud.double(forKey: "vpBoundsG"),
-            blue: ud.double(forKey: "vpBoundsB"),
-            opacity: ud.double(forKey: "vpBoundsA")
+            red: ud.double(forKey: DefaultsKey.viewportBoundsR),
+            green: ud.double(forKey: DefaultsKey.viewportBoundsG),
+            blue: ud.double(forKey: DefaultsKey.viewportBoundsB),
+            opacity: ud.double(forKey: DefaultsKey.viewportBoundsA)
         )
     }
 
@@ -264,10 +265,10 @@ class AppSettings {
     private func saveViewportBoundsColor() {
         let c = resolvedRGBA()
         let ud = UserDefaults.standard
-        ud.set(Double(c.r), forKey: "vpBoundsR")
-        ud.set(Double(c.g), forKey: "vpBoundsG")
-        ud.set(Double(c.b), forKey: "vpBoundsB")
-        ud.set(Double(c.a), forKey: "vpBoundsA")
+        ud.set(Double(c.r), forKey: DefaultsKey.viewportBoundsR)
+        ud.set(Double(c.g), forKey: DefaultsKey.viewportBoundsG)
+        ud.set(Double(c.b), forKey: DefaultsKey.viewportBoundsB)
+        ud.set(Double(c.a), forKey: DefaultsKey.viewportBoundsA)
     }
 
     func pushViewportBoundsColor() {

--- a/ios/Empo/src/App/AppState.swift
+++ b/ios/Empo/src/App/AppState.swift
@@ -148,7 +148,7 @@ class AppState {
         guard let files = try? fm.contentsOfDirectory(at: logsDir, includingPropertiesForKeys: [.creationDateKey]) else { return }
 
         let logFiles = files.filter { $0.lastPathComponent != "session-history.log" && $0.pathExtension == "log" }
-        let maxLogFiles = UserDefaults.standard.object(forKey: "maxLogFiles") as? Int ?? 20
+        let maxLogFiles = UserDefaults.standard.object(forKey: DefaultsKey.maxLogFiles) as? Int ?? 20
         guard logFiles.count > maxLogFiles else { return }
 
         let sorted = logFiles.sorted {

--- a/ios/Empo/src/App/DefaultsKey.swift
+++ b/ios/Empo/src/App/DefaultsKey.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Central registry of every UserDefaults key this app reads or
+/// writes. Call sites reference these constants instead of literal
+/// strings so that renaming a key is a one-line change and a grep
+/// across the project surfaces every consumer immediately.
+///
+/// Three shapes are supported:
+///
+///   - Fixed-name keys: plain `static let` constants. Most keys.
+///   - Parameterized key families: `static func key(for: ...) -> String`.
+///     Use these for per-entity storage (e.g. per-game, per-tip).
+///   - Enum-backed key families: the `ExperimentalFeature` enum's
+///     `rawValue` drives the key set directly. The raw values are
+///     namespaced with an `experimental.*` prefix so they stay visually
+///     grouped alongside the fixed-name keys.
+enum DefaultsKey {
+    // MARK: - App-wide
+
+    static let theme = "theme"
+    static let debugMode = "debugMode"
+    static let showViewportBounds = "showViewportBounds"
+    static let debugLogs = "debugLogs"
+    static let maxLogFiles = "maxLogFiles"
+    static let interfaceHaptics = "interfaceHaptics"
+    static let controllerHaptics = "controllerHaptics"
+
+    // MARK: - Disclaimer
+
+    static let disclaimerAcknowledgedVersion = "disclaimerAcknowledgedVersion"
+
+    // MARK: - Library
+
+    static let cleanupInvalidGames = "cleanupInvalidGames"
+    static let libraryDisplayMode = "libraryDisplayMode"
+    static let librarySortOption = "librarySortOption"
+    static let showContinuePlaying = "showContinuePlaying"
+    static let titlePosition = "titlePosition"
+
+    // MARK: - Viewport bounds overlay color
+
+    static let viewportBoundsR = "vpBoundsR"
+    static let viewportBoundsG = "vpBoundsG"
+    static let viewportBoundsB = "vpBoundsB"
+    static let viewportBoundsA = "vpBoundsA"
+
+    // MARK: - Player (parameterized families)
+
+    /// Per-game controls layout. `controlsLayout.<gameID>` -> JSON.
+    static let controlsLayoutPrefix = "controlsLayout."
+    static func controlsLayout(gameID: String) -> String {
+        controlsLayoutPrefix + gameID
+    }
+
+    // MARK: - Tips (parameterized family)
+
+    /// A tip's dismissed-at timestamp. `tip.dismissed.<tipID>` -> Double.
+    static let tipDismissedPrefix = "tip.dismissed."
+    static func tipDismissed(tipID: String) -> String {
+        tipDismissedPrefix + tipID
+    }
+}

--- a/ios/Empo/src/Library/GameLibrary.swift
+++ b/ios/Empo/src/Library/GameLibrary.swift
@@ -28,7 +28,7 @@ class GameLibrary {
 
     func reload(initialLoad: Bool = false) {
         let cleanupInvalid = initialLoad
-            ? UserDefaults.standard.bool(forKey: "cleanupInvalidGames")
+            ? UserDefaults.standard.bool(forKey: DefaultsKey.cleanupInvalidGames)
             : false
         Task.detached {
             let scanned = GameLibrary.scanGames(in: GameLibrary.gamesDirectory, cleanupInvalid: cleanupInvalid)
@@ -111,31 +111,11 @@ class GameLibrary {
         let iniTitle = GameEntry.parseINITitle(at: url) ?? "Unknown Game"
         let defaultArtwork = findArtwork(at: url)
 
-        // ID is the UUID prefix (first 36 chars) of the folder name.
-        // Legacy folders without a UUID use the full folder name.
-        let id: String
-        if folderName.count >= 36,
-           UUID(uuidString: String(folderName.prefix(36))) != nil {
-            id = String(folderName.prefix(36))
-        } else {
-            id = folderName
-        }
+        // Import writes the UUID as the first 36 chars of the folder
+        // name. The game's id is just that UUID.
+        let id = String(folderName.prefix(36))
 
-        // Load metadata for custom title/artwork overrides
-        var metadata = GameMetadata.load(for: id)
-        var needsSave = false
-
-        // Set dateAdded retroactively if not present (pre-existing game)
-        if metadata.dateAdded == nil {
-            let attrs = try? fm.attributesOfItem(atPath: url.path)
-            metadata.dateAdded = (attrs?[.creationDate] as? Date) ?? Date()
-            needsSave = true
-        }
-
-        if needsSave {
-            metadata.save(for: id)
-        }
-
+        let metadata = GameMetadata.load(for: id)
         let title = metadata.customTitle ?? iniTitle
         let artworkPath = metadata.customArtworkPath(for: id) ?? defaultArtwork
         let originalTitle = metadata.customTitle != nil ? iniTitle : nil

--- a/ios/Empo/src/Player/ControlsLayout.swift
+++ b/ios/Empo/src/Player/ControlsLayout.swift
@@ -10,8 +10,6 @@ struct ButtonModel: Identifiable, Equatable, Codable {
     var size: CGFloat
     /// Per-button opacity in [0, 1]. Applied to the whole button view,
     /// so it tones down both the glass background and the label.
-    /// Defaults to 1.0 (fully opaque) for new and legacy-decoded
-    /// buttons so existing saved layouts remain unchanged.
     var opacity: Double
 
     enum CodingKeys: String, CodingKey {
@@ -70,15 +68,6 @@ private struct PersistedLayout: Codable {
 class ControlsLayout {
     static let shared = ControlsLayout()
 
-    /// UserDefaults key prefix. The full key for a given game is
-    /// `controlsLayout.<gameID>`. The pre-per-game global key
-    /// (`touchControlsLayout`) is removed during `switchGame` to
-    /// avoid leaving an orphan entry behind for users who launched
-    /// the app before this change. Since the app isn't live yet, no
-    /// migration is needed - all games start at factory defaults.
-    private static let savedLayoutKeyPrefix = "controlsLayout."
-    private static let legacyGlobalKey = "touchControlsLayout"
-
     /// Stable identifier of the game these controls are currently
     /// bound to. `switchGame(id:)` updates this; mutators save to the
     /// corresponding per-game key. `nil` means no game is active -
@@ -92,15 +81,7 @@ class ControlsLayout {
     var buttons: [ButtonModel] = []
 
     private init() {
-        // No game bound yet - just populate with factory defaults so
-        // library-screen UI that reads the layout (if any) sees a
-        // sensible state. Actual loads happen on `switchGame(id:)`.
         resetToDefaults()
-
-        // Remove the pre-per-game global key if it's still hanging
-        // around from an older build. Idempotent; runs on every
-        // process launch.
-        UserDefaults.standard.removeObject(forKey: Self.legacyGlobalKey)
     }
 
     /// Bind the layout instance to a specific game's stored layout.
@@ -127,7 +108,7 @@ class ControlsLayout {
 
     private var savedLayoutKey: String? {
         guard let id = currentGameID else { return nil }
-        return Self.savedLayoutKeyPrefix + id
+        return DefaultsKey.controlsLayout(gameID: id)
     }
 
 

--- a/ios/Empo/src/Player/GameControls.swift
+++ b/ios/Empo/src/Player/GameControls.swift
@@ -1,9 +1,7 @@
 import SwiftUI
 
 /// On-screen action button and D-pad, rendered with SwiftUI + the
-/// Liquid Glass material (iOS 26+). These are the only implementation
-/// of the touch controls - the legacy UIKit views were removed along
-/// with the migration feature flag.
+/// Liquid Glass material.
 ///
 /// Touch-dispatch semantics:
 ///   - `mkxp_injectKeyEvent(scancode, 1)` on press-down,
@@ -67,8 +65,7 @@ struct ActionButton: View {
         .gesture(editing ? nil : pressGesture)
         // If the user enters edit mode while this button is pressed, or
         // the button is removed from the layout while pressed, release
-        // the key explicitly. UIKit's touchesCancelled is unreliable in
-        // these cases - we saw stuck keys in the legacy impl.
+        // the key explicitly.
         .onChange(of: editing) { _, newValue in
             if newValue {
                 releaseIfHeld()

--- a/ios/Empo/src/Tips/Tip.swift
+++ b/ios/Empo/src/Tips/Tip.swift
@@ -41,16 +41,15 @@ extension Tip {
 final class TipStore {
     static let shared = TipStore()
 
-    private static let prefix = "tip.dismissed."
-
     private var dismissedAt: [String: Date]
 
     private init() {
         var loaded: [String: Date] = [:]
         let defaults = UserDefaults.standard
         let allKeys = defaults.dictionaryRepresentation().keys
-        for key in allKeys where key.hasPrefix(Self.prefix) {
-            let tipID = String(key.dropFirst(Self.prefix.count))
+        let prefix = DefaultsKey.tipDismissedPrefix
+        for key in allKeys where key.hasPrefix(prefix) {
+            let tipID = String(key.dropFirst(prefix.count))
             if let timestamp = defaults.object(forKey: key) as? Double {
                 loaded[tipID] = Date(timeIntervalSince1970: timestamp)
             }
@@ -74,6 +73,9 @@ final class TipStore {
         guard tip.isDismissable else { return }
         let now = Date()
         dismissedAt[tip.id] = now
-        UserDefaults.standard.set(now.timeIntervalSince1970, forKey: Self.prefix + tip.id)
+        UserDefaults.standard.set(
+            now.timeIntervalSince1970,
+            forKey: DefaultsKey.tipDismissed(tipID: tip.id)
+        )
     }
 }


### PR DESCRIPTION
Introduces `DefaultsKey` - a single enum that holds every UserDefaults key the app reads or writes. All call sites now reference the registry instead of literal strings so renaming a key is a one-line change and a grep surfaces every consumer.

## Changes

- New `DefaultsKey.swift` with fixed-name keys, parameterized key factories (`controlsLayout(gameID:)`, `tipDismissed(tipID:)`), and the `viewportBounds*` RGBA set.
- All consumers migrated: `AppSettings`, `AppState`, `GameLibrary`, `ControlsLayout`, `Tip`.
- Two cross-file keys that were previously hazards are now impossible to silently rename: `maxLogFiles` (AppSettings+AppState) and `cleanupInvalidGames` (AppSettings+GameLibrary).

## Dropped (app isn't shipped yet, no installed users to migrate)

- `legacyControlsLayout` cleanup path (`touchControlsLayout` key removal on launch).
- Legacy non-UUID folder-name fallback in `GameLibrary.buildGameEntry` - folder ids are always the UUID prefix now.
- `dateAdded` retroactive-set for pre-existing games.
- Comment nits that referenced the now-dropped migrations ("legacy-decoded buttons", "we saw stuck keys in the legacy impl", etc.).

## Tested

- Simulator build clean
- App launches, library populates, games playable
- Per-game controls layout persists correctly across quit/relaunch
- Per-game isolation still works (edits on one game don't leak to another)
- AppSettings keys (theme, haptics, display mode, sort) all persist

No behavior changes. Pure refactor.