### PR TITLE
refactor: consolidate design tokens in theme

### DIFF
--- a/ios/Empo/src/App/RootView.swift
+++ b/ios/Empo/src/App/RootView.swift
@@ -171,14 +171,9 @@ private struct SplashView: View {
             // treatment on the full exit.
             VStack(spacing: Spacing.lg) {
                 Text(AppInfo.name)
-                    .font(.system(size: 40))
-                    .fontWeight(.bold)
-                    .fontDesign(.rounded)
+                    .font(AppFont.wordmark)
                     .foregroundStyle(.white)
-                    // Matches the game title shadow in GameLoadingView
-                    // so the splash and the loading view feel like the
-                    // same moment from the user's perspective.
-                    .shadow(radius: 4)
+                    .heroTitleShadow()
             }
             .blur(radius: logoHidden ? 10 : 0)
             .scaleEffect(logoHidden ? 0.8 : (entered ? 1 : 0.8))

--- a/ios/Empo/src/Design/Theme.swift
+++ b/ios/Empo/src/Design/Theme.swift
@@ -113,6 +113,39 @@ extension View {
     func elevatedShadow() -> some View {
         shadow(color: .black.opacity(0.25), radius: 8, y: 4)
     }
+
+    /// Drop shadow used on hero title text overlaid on game artwork,
+    /// both on the splash and inside game-loading screens.
+    func heroTitleShadow() -> some View {
+        shadow(radius: 4)
+    }
+
+    /// Pin the Liquid Glass material to its dark variant. Used on
+    /// player controls (toolbar, D-pad, action buttons, debug
+    /// overlay) so the glass tone stays consistent regardless of
+    /// system color scheme or backdrop brightness.
+    func darkGlass() -> some View {
+        environment(\.colorScheme, .dark)
+    }
+}
+
+
+/// Typography tokens used for one-off sites that don't fit a
+/// SwiftUI semantic text style. Prefer a semantic font
+/// (`.body`, `.headline`) first; reach for these only when the
+/// design needs a specific tuned size/weight/design.
+enum AppFont {
+    /// The Empo wordmark - splash and settings header.
+    static let wordmark = Font.system(size: 40, weight: .bold, design: .rounded)
+
+    /// A small bold button label (used by inline CTAs and chips).
+    static let buttonSmall = Font.footnote.weight(.semibold)
+
+    /// Fixed-width monospaced body for the debug overlay.
+    static let debugBody = Font.footnote.monospaced()
+
+    /// Bold monospaced title for the debug overlay.
+    static let debugTitle = Font.body.bold().monospaced()
 }
 
 //
@@ -121,22 +154,59 @@ extension View {
 enum Motion {
     // -- Small elements: buttons, toggles, icons (150-200ms) --
 
-    /// Quick micro-interaction — button press, toggle, small state change.
+    /// Quick micro-interaction - button press, toggle, small state change.
     static let snappy = Animation.spring(duration: 0.18, bounce: 0.0)
 
     // -- Big elements: cards, rows, navigation, layout shifts (250-350ms) --
 
-    /// General-purpose transition — list changes, layout shifts, navigation.
+    /// General-purpose transition - list changes, layout shifts, navigation.
     static let standard = Animation.spring(duration: 0.3, bounce: 0.0)
 
-    /// Gentle transition — background changes, slow reveals.
+    /// Gentle transition - background changes, slow reveals.
     static let gentle = Animation.spring(duration: 0.35, bounce: 0.0)
 
-    /// Slow emphasis — loading reveals, large layout shifts.
+    /// Slow emphasis - loading reveals, large layout shifts.
     static let slow = Animation.spring(duration: 0.5, bounce: 0.0)
 
+    // -- Specialized presets --
 
-    /// Fast — opacity fades, color changes (small elements).
+    /// Interactive press response - action buttons, D-pad. Paired with
+    /// `PressScale.standard`.
+    static let controlPress = Animation.spring(response: 0.2, dampingFraction: 0.7)
+
+    /// Near-instant state change - per-arm highlight on / off in the
+    /// D-pad, slider thumb snap, etc.
+    static let instant = Animation.easeOut(duration: 0.08)
+
+    /// Soft bouncy - import button arc, tip banner entrance.
+    static let bouncy = Animation.spring(duration: 0.25, bounce: 0.15)
+
+    /// Emphasized transition - loading handoffs, reveal beats.
+    static let emphasize = Animation.spring(duration: 0.8, bounce: 0)
+
+    /// Ambient float used on splash artwork and similar long-running
+    /// decorative loops. Always `.repeatForever(autoreverses: true)`.
+    static let float = Animation.easeInOut(duration: 2.4)
+        .repeatForever(autoreverses: true)
+
+    /// Spinner rotation - linear and looping.
+    static let spinner = Animation.linear(duration: 1)
+        .repeatForever(autoreverses: false)
+
+    // -- Stagger --
+
+    /// Interval between successive items in a cascading entrance
+    /// (library grid, settings list). Slightly longer than
+    /// `staggerFast` so a row of 6-8 items reads as a wave.
+    static let staggerInterval: TimeInterval = 0.04
+
+    /// Faster stagger used in denser/wider lists where the sum of
+    /// delays would otherwise feel sluggish.
+    static let staggerFast: TimeInterval = 0.04
+
+    // -- Durations (for manual withAnimation(.easeInOut(duration:))) --
+
+    /// Fast - opacity fades, color changes (small elements).
     static let durationFast: TimeInterval = 0.18
     /// Normal - standard transitions (big elements).
     static let durationNormal: TimeInterval = 0.3
@@ -144,6 +214,15 @@ enum Motion {
     static let durationGentle: TimeInterval = 0.35
     /// Slow - emphasis transitions, loading reveals.
     static let durationSlow: TimeInterval = 0.5
+}
+
+
+/// Press-scale values used when a button-like surface reacts to
+/// touch. Kept as one canonical number so action buttons, cards, and
+/// the D-pad press identically.
+enum PressScale {
+    /// The standard press-down scale.
+    static let standard: CGFloat = 0.95
 }
 
 
@@ -156,11 +235,62 @@ enum AppSize {
     /// actual rendered size via `DebugOverlayHeightKey`. Long titles or
     /// wrapped lines make the real height grow beyond this.
     static let debugOverlayInitialHeight: CGFloat = 140
+
+    /// Library/settings navigation header tap area.
+    static let libraryHeader: CGFloat = 56
+
+    /// Slider value-label pinned width (right-aligned, so values like
+    /// "100%" don't visually jump as the label width fluctuates).
+    static let sliderValueLabel: CGFloat = 48
 }
 
 
-enum Overlay {
+/// SF Symbol and small-icon sizing. Use instead of inline
+/// `.font(.system(size: N))` on `Image(systemName:)` so icons stay
+/// consistent across the app.
+enum IconSize {
+    /// Inline icon in a settings row, list row, or chip.
+    static let row: CGFloat = 24
+    /// Placeholder icon inside an empty slot (e.g. missing artwork).
+    static let placeholder: CGFloat = 36
+    /// Hero icon inside an empty-state illustration.
+    static let emptyState: CGFloat = 48
+}
+
+
+/// Layered opacity tokens. Semantics:
+///
+/// - `Scrim.*` dims what's behind (typically black over the game
+///   or a card).
+/// - `Alpha.*` is for foreground content opacity (text, icons, rim
+///   strokes, hairline dividers).
+enum Scrim {
+    /// Soft scrim - subtle veil (e.g. bottom-of-hero gradient).
     static let light: Double = 0.3
+    /// Medium scrim - typical modal dim.
     static let medium: Double = 0.5
+    /// Heavy scrim - full darken (e.g. disclaimer backdrop).
     static let heavy: Double = 0.6
+}
+
+
+enum Alpha {
+    /// Muted foreground - secondary text/icons over images.
+    static let textMuted: Double = 0.7
+    /// High-opacity foreground - primary labels over images.
+    static let textHighMuted: Double = 0.9
+    /// Subtle rim or hairline divider.
+    static let border: Double = 0.2
+    /// Brand tint behind `.secondary` surfaces.
+    static let brandTintBackground: Double = 0.1
+}
+
+
+/// Backwards-compat shim so incremental site-by-site migration is
+/// safe: existing `Overlay.light/medium/heavy` call sites keep
+/// working while we migrate to the split `Scrim` / `Alpha` tokens.
+enum Overlay {
+    static let light: Double = Scrim.light
+    static let medium: Double = Scrim.medium
+    static let heavy: Double = Scrim.heavy
 }

--- a/ios/Empo/src/Library/GameCard.swift
+++ b/ios/Empo/src/Library/GameCard.swift
@@ -41,7 +41,7 @@ struct GameCard: View {
                     // readable against every artwork.  Scoped here so
                     // the artwork placeholder underneath keeps its
                     // actual-scheme color.
-                    .environment(\.colorScheme, .dark)
+                    .darkGlass()
             }
             .overlay(alignment: .bottomLeading) {
                 VStack(alignment: .leading, spacing: 1) {

--- a/ios/Empo/src/Library/GameLoadingView.swift
+++ b/ios/Empo/src/Library/GameLoadingView.swift
@@ -51,7 +51,7 @@ struct GameLoadingView: View {
                     .font(.title)
                     .fontWeight(.bold)
                     .foregroundStyle(.white)
-                    .shadow(radius: 4)
+                    .heroTitleShadow()
                     .opacity(titleVisible ? 1 : 0)
                     .offset(y: titleVisible ? 0 : 12)
 

--- a/ios/Empo/src/Library/ImportButton.swift
+++ b/ios/Empo/src/Library/ImportButton.swift
@@ -137,7 +137,7 @@ struct ImportButton: View {
             height: collapsed ? AppSize.toolbarButton : nil
         )
         .glassEffect(.regular.tint(.brand).interactive(), in: .capsule)
-        .environment(\.colorScheme, .dark)
+        .darkGlass()
     }
 }
 

--- a/ios/Empo/src/Player/DebugOverlayView.swift
+++ b/ios/Empo/src/Player/DebugOverlayView.swift
@@ -79,7 +79,7 @@ struct DebugOverlayView: View {
         }
         .padding(Spacing.md + Spacing.xxs)
         .glassEffect(.regular, in: RoundedRectangle(cornerRadius: Radius.sm + Spacing.xxs))
-        .environment(\.colorScheme, .dark)
+        .darkGlass()
         .background(
             GeometryReader { proxy in
                 Color.clear.preference(

--- a/ios/Empo/src/Player/GameControls.swift
+++ b/ios/Empo/src/Player/GameControls.swift
@@ -50,13 +50,13 @@ struct ActionButton: View {
                 .foregroundStyle(.white.opacity(0.9))
         }
         .frame(width: size, height: size)
-        .scaleEffect(isPressed ? 0.95 : 1.0)
-        .animation(.spring(response: 0.2, dampingFraction: 0.7), value: isPressed)
+        .scaleEffect(isPressed ? PressScale.standard : 1.0)
+        .animation(Motion.controlPress, value: isPressed)
         // Force the dark Liquid Glass variant to match the D-pad.
         // Both controls pin to `.dark` so the glass material looks
         // consistent regardless of the system interface style or
         // the brightness of the game content behind them.
-        .environment(\.colorScheme, .dark)
+        .darkGlass()
         .contentShape(Circle())
         // Touch dispatch. minimumDistance=0 makes this a press-tracking
         // gesture that fires on touch-down (not after a drag threshold).
@@ -184,7 +184,7 @@ struct DPad: View {
                             )
                         )
                         .opacity(activeDirections.contains(dir) ? 1 : 0)
-                        .animation(.easeOut(duration: 0.08), value: activeDirections)
+                        .animation(Motion.instant, value: activeDirections)
                 }
             }
             .clipShape(plus)
@@ -208,8 +208,8 @@ struct DPad: View {
         // alone scales only the glass layer; this keeps everything
         // visually coherent including the highlights' clip against
         // the plus silhouette.
-        .scaleEffect(pressed ? 0.96 : 1.0)
-        .animation(.spring(response: 0.2, dampingFraction: 0.7), value: pressed)
+        .scaleEffect(pressed ? PressScale.standard : 1.0)
+        .animation(Motion.controlPress, value: pressed)
         // Force the dark Liquid Glass variant so the plus clip shape
         // doesn't render noticeably brighter than the action buttons'
         // circles. With the default (system) color scheme, iOS 26's
@@ -219,7 +219,7 @@ struct DPad: View {
         // D-pad next to translucent-dark action buttons. Pinning to
         // .dark here locks the material in one mode and keeps the
         // two visually consistent.
-        .environment(\.colorScheme, .dark)
+        .darkGlass()
         // Hit-test the full bounding circle so slightly imprecise
         // presses (between arms, just outside the plus shape) still
         // engage. The wedge math in updateDirections decides which

--- a/ios/Empo/src/Player/PlayerView.swift
+++ b/ios/Empo/src/Player/PlayerView.swift
@@ -312,7 +312,7 @@ struct PlayerView: View {
         // toolbar matches the on-screen controls (D-pad, action
         // buttons) and doesn't shift appearance with the system
         // color scheme or the backdrop brightness of the game.
-        .environment(\.colorScheme, .dark)
+        .darkGlass()
         .opacity(toolbarOpacity)
         .position(toolbarPosition)
     }

--- a/ios/Empo/src/Settings/SettingsView.swift
+++ b/ios/Empo/src/Settings/SettingsView.swift
@@ -24,9 +24,7 @@ struct SettingsView: View {
                         // first run and the settings header feel
                         // continuous.
                         Text(AppInfo.name)
-                            .font(.system(size: 40))
-                            .fontWeight(.bold)
-                            .fontDesign(.rounded)
+                            .font(AppFont.wordmark)
                         // Tap the marketing version to reveal full build
                         // details (commit, dirty flag, non-default branch).
                         Button {


### PR DESCRIPTION
Tier 2 of audit roadmap. Centralizes Motion, AppFont, AppSize, IconSize, Scrim/Alpha, PressScale tokens in Theme.swift. Adds heroTitleShadow() and darkGlass() view modifiers. Migrates scattered call sites to use the registry. Fixes press-scale inconsistency (0.95 vs 0.96) across controls.