### PR TITLE
refactor: inject app services via swiftui environment

### DIFF
--- a/ios/Empo/src/App/AppEnvironment.swift
+++ b/ios/Empo/src/App/AppEnvironment.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+/// SwiftUI environment injection for app-wide services.
+///
+/// Views read services via `@Environment(\.appState)` etc. instead of
+/// reaching into `AppState.shared`. A single composition root (RootView)
+/// injects instances once; nested views inherit them automatically.
+///
+/// Non-UI code (C bridge callbacks, AppWindow statics, Haptics) still
+/// uses `.shared` because SwiftUI environment isn't reachable from
+/// those contexts.
+
+private struct AppStateKey: EnvironmentKey {
+    @MainActor static let defaultValue: AppState = .shared
+}
+
+private struct AppSettingsKey: EnvironmentKey {
+    @MainActor static let defaultValue: AppSettings = .shared
+}
+
+private struct EngineStateKey: EnvironmentKey {
+    @MainActor static let defaultValue: EngineState = .shared
+}
+
+private struct PauseManagerKey: EnvironmentKey {
+    @MainActor static let defaultValue: PauseManager = .shared
+}
+
+private struct GameLibraryKey: EnvironmentKey {
+    @MainActor static let defaultValue: GameLibrary = .shared
+}
+
+private struct ControlsLayoutKey: EnvironmentKey {
+    @MainActor static let defaultValue: ControlsLayout = .shared
+}
+
+private struct TipStoreKey: EnvironmentKey {
+    @MainActor static let defaultValue: TipStore = .shared
+}
+
+extension EnvironmentValues {
+    var appState: AppState {
+        get { self[AppStateKey.self] }
+        set { self[AppStateKey.self] = newValue }
+    }
+
+    var appSettings: AppSettings {
+        get { self[AppSettingsKey.self] }
+        set { self[AppSettingsKey.self] = newValue }
+    }
+
+    var engineState: EngineState {
+        get { self[EngineStateKey.self] }
+        set { self[EngineStateKey.self] = newValue }
+    }
+
+    var pauseManager: PauseManager {
+        get { self[PauseManagerKey.self] }
+        set { self[PauseManagerKey.self] = newValue }
+    }
+
+    var gameLibrary: GameLibrary {
+        get { self[GameLibraryKey.self] }
+        set { self[GameLibraryKey.self] = newValue }
+    }
+
+    var controlsLayout: ControlsLayout {
+        get { self[ControlsLayoutKey.self] }
+        set { self[ControlsLayoutKey.self] = newValue }
+    }
+
+    var tipStore: TipStore {
+        get { self[TipStoreKey.self] }
+        set { self[TipStoreKey.self] = newValue }
+    }
+}

--- a/ios/Empo/src/App/RootView.swift
+++ b/ios/Empo/src/App/RootView.swift
@@ -7,14 +7,20 @@ private enum SplashTiming {
 }
 
 struct RootView: View {
-    private let appState = AppState.shared
-    private let engineState = EngineState.shared
-    private let layout = ControlsLayout.shared
-    private let settings = AppSettings.shared
+    @Environment(\.appState) private var appState
+    @Environment(\.engineState) private var engineState
+    @Environment(\.controlsLayout) private var layout
+    @Environment(\.appSettings) private var settings
     @Namespace private var hero
-    @State private var showSplash = !AppState.shared.pendingCrashRecovery
+    @State private var showSplash: Bool
     @State private var splashExiting = false
-    @State private var splashDismissed = AppState.shared.pendingCrashRecovery
+    @State private var splashDismissed: Bool
+
+    init() {
+        let recovering = AppState.shared.pendingCrashRecovery
+        _showSplash = State(initialValue: !recovering)
+        _splashDismissed = State(initialValue: recovering)
+    }
     /// When true, the splash logo cross-fades out and the disclaimer
     /// cross-fades in on top of the same orange background. Flipped at
     /// the 1.2s mark only if the user hasn't acknowledged yet.

--- a/ios/Empo/src/Library/GameCard.swift
+++ b/ios/Empo/src/Library/GameCard.swift
@@ -4,9 +4,10 @@ struct GameCard: View {
     let game: GameEntry
     var isPaused: Bool = false
     var onStopImport: (() -> Void)? = nil
+    @Environment(\.appSettings) private var settings
     @State private var titleHeight: CGFloat = 40
 
-    private var titlePosition: TitlePosition { AppSettings.shared.titlePosition }
+    private var titlePosition: TitlePosition { settings.titlePosition }
 
     var body: some View {
         switch titlePosition {

--- a/ios/Empo/src/Library/GameContextMenu.swift
+++ b/ios/Empo/src/Library/GameContextMenu.swift
@@ -9,8 +9,9 @@ struct GameContextMenuModifier: ViewModifier {
     @Binding var showDeleteConfirm: Bool
     @Binding var gameForSettings: GameEntry?
     @Binding var gameForInfo: GameEntry?
+    @Environment(\.pauseManager) private var pauseManager
 
-    private var isPaused: Bool { PauseManager.shared.pausedGame?.id == game.id }
+    private var isPaused: Bool { pauseManager.pausedGame?.id == game.id }
 
     func body(content: Content) -> some View {
         content.contextMenu {

--- a/ios/Empo/src/Library/GameInfoView.swift
+++ b/ios/Empo/src/Library/GameInfoView.swift
@@ -2,7 +2,9 @@ import SwiftUI
 
 struct GameInfoView: View {
     let game: GameEntry
-    var library = GameLibrary.shared
+    @Environment(\.gameLibrary) private var library
+    @Environment(\.tipStore) private var tipStore
+    @Environment(\.appSettings) private var settings
     @Environment(\.dismiss) private var dismiss
 
     @State private var metadata: GameMetadata
@@ -15,7 +17,6 @@ struct GameInfoView: View {
     @State private var navBarBottomY: CGFloat = 0
     @State private var needsLibraryRefresh = false
     @FocusState private var isTitleFocused: Bool
-    private var tipStore = TipStore.shared
 
     private let originalTitle: String
 
@@ -130,7 +131,7 @@ struct GameInfoView: View {
                                 .padding(.vertical, Spacing.lg)
                         }
 
-                    if let logURL = sessionLogURL(), AppSettings.shared.debugLogs {
+                    if let logURL = sessionLogURL(), settings.debugLogs {
                         Divider().padding(.leading, Spacing.xl)
 
                         ShareLink(item: logURL) {

--- a/ios/Empo/src/Library/GameLibraryView.swift
+++ b/ios/Empo/src/Library/GameLibraryView.swift
@@ -29,8 +29,9 @@ struct GameLibraryView: View {
     var appState: AppState
     var heroNamespace: Namespace.ID
     var splashDismissed: Bool = true
-    var library = GameLibrary.shared
-    var settings = AppSettings.shared
+    @Environment(\.gameLibrary) private var library
+    @Environment(\.appSettings) private var settings
+    @Environment(\.pauseManager) private var pauseManager
     @State private var showImporter = false
     @State private var showSettings = false
     @State private var errorMessage: String?
@@ -231,7 +232,7 @@ struct GameLibraryView: View {
                     path.append(game)
                 }
             } message: {
-                if let paused = PauseManager.shared.pausedGame {
+                if let paused = pauseManager.pausedGame {
                     Text("\"\(paused.title)\" is still running. Quit it to play a different game?")
                 }
             }
@@ -387,7 +388,7 @@ struct GameLibraryView: View {
 
 
     private func heroCard(for game: GameEntry) -> some View {
-        let isPaused = PauseManager.shared.pausedGame?.id == game.id
+        let isPaused = pauseManager.pausedGame?.id == game.id
         // In landscape the narrower vertical space means a 2.2:1 ratio
         // hero card eats most of the screen and pushes the grid below
         // the fold. Widen it in compact-height so the card stays
@@ -397,7 +398,7 @@ struct GameLibraryView: View {
     }
 
     private func heroListRow(for game: GameEntry) -> some View {
-        let isPaused = PauseManager.shared.pausedGame?.id == game.id
+        let isPaused = pauseManager.pausedGame?.id == game.id
         let ratio: CGFloat = verticalSizeClass == .compact ? 5.0 : 3.0
         return heroCardContent(for: game, isPaused: isPaused, aspectRatio: ratio)
     }
@@ -484,7 +485,7 @@ struct GameLibraryView: View {
             }
 
             ForEach(Array(filteredGames.enumerated()), id: \.element.id) { index, game in
-                let isPaused = PauseManager.shared.pausedGame?.id == game.id
+                let isPaused = pauseManager.pausedGame?.id == game.id
                 Button {
                     switch game.status {
                     case .ready: handleGameTap(game, from: .item)
@@ -542,7 +543,7 @@ struct GameLibraryView: View {
                     .staggered(index: index, trigger: staggerTrigger, initialDelay: entranceDelay)
 
             case .ready:
-                let isPaused = PauseManager.shared.pausedGame?.id == game.id
+                let isPaused = pauseManager.pausedGame?.id == game.id
                 Button { handleGameTap(game, from: .item) } label: {
                     GameCard(game: game, isPaused: isPaused)
                         .matchedTransitionSource(id: GameTapSource.item.transitionID(for: game.id),
@@ -571,7 +572,6 @@ struct GameLibraryView: View {
 
     private func handleGameTap(_ game: GameEntry, from source: GameTapSource = .item) {
         tappedSource[game.id] = source
-        let pauseManager = PauseManager.shared
         if pauseManager.pausedGame?.id == game.id {
             appState.resumePausedGame()
             path.append(game)

--- a/ios/Empo/src/Library/GameLoadingView.swift
+++ b/ios/Empo/src/Library/GameLoadingView.swift
@@ -4,9 +4,9 @@ struct GameLoadingView: View {
     enum Mode { case loading, resuming }
 
     let game: GameEntry
-    var appState = AppState.shared
-    var engineState = EngineState.shared
-    var pauseManager = PauseManager.shared
+    @Environment(\.appState) private var appState
+    @Environment(\.engineState) private var engineState
+    @Environment(\.pauseManager) private var pauseManager
 
     private var mode: Mode { pauseManager.pauseSnapshot != nil ? .resuming : .loading }
 

--- a/ios/Empo/src/Player/PlayerView.swift
+++ b/ios/Empo/src/Player/PlayerView.swift
@@ -16,7 +16,8 @@ struct PlayerView: View {
     @Bindable var appState: AppState
     @Bindable var engineState: EngineState
     var layout: ControlsLayout
-    var pauseManager = PauseManager.shared
+    @Environment(\.pauseManager) private var pauseManager
+    @Environment(\.appSettings) private var settings
     @State private var editMode = false
     @State private var controlsHidden = false
     @State private var keyboardMode = false
@@ -277,16 +278,16 @@ struct PlayerView: View {
 
         let buttons: [(icon: String, label: String, action: () -> Void, tint: Color?)] = {
             var list: [(icon: String, label: String, action: () -> Void, tint: Color?)] = []
-            if AppSettings.shared.isEnabled(.gamePause) {
+            if settings.isEnabled(.gamePause) {
                 list.append(("pause.fill", "Pause game", { appState.requestPause() }, .white))
             }
             list.append(("keyboard", "Toggle keyboard", { toggleKeyboard() }, .white))
-            if AppSettings.shared.debugMode {
+            if settings.debugMode {
                 list.append(("chart.line.uptrend.xyaxis", "Debug overlay", { showDebugOverlay.toggle() }, .white))
             }
             list.append(("gearshape.fill", "Edit controls", { toggleEditMode() }, .white))
             list.append((controlsHidden ? "eye.slash.fill" : "eye.fill", controlsHidden ? "Show controls" : "Hide controls", { toggleHideControls() }, .white))
-            if AppSettings.shared.isEnabled(.gameQuit) {
+            if settings.isEnabled(.gameQuit) {
                 list.append(("xmark.circle.fill", "Quit game", { showQuitConfirm = true }, .destructive))
             }
             return list

--- a/ios/Empo/src/Settings/SettingsView.swift
+++ b/ios/Empo/src/Settings/SettingsView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct SettingsView: View {
-    @Bindable var settings = AppSettings.shared
+    @Environment(\.appSettings) private var settings
     @Environment(\.dismiss) private var dismiss
     @State private var confirmation: ExperimentalConfirmation?
     @State private var showBuildInfo = false
@@ -16,7 +16,8 @@ struct SettingsView: View {
 
 
     var body: some View {
-        NavigationStack {
+        @Bindable var settings = settings
+        return NavigationStack {
             Form {
                 Section {
                     VStack(spacing: Spacing.md) {

--- a/ios/Empo/src/Tips/TipBanner.swift
+++ b/ios/Empo/src/Tips/TipBanner.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct TipBanner: View {
     let tip: Tip
-    var store = TipStore.shared
+    @Environment(\.tipStore) private var store
 
     @State private var showDetail = false
 


### PR DESCRIPTION
Tier 5.1 of audit roadmap. Adds EnvironmentKey + EnvironmentValues entries for AppState, AppSettings, EngineState, PauseManager, GameLibrary, ControlsLayout, TipStore. Migrates all SwiftUI views to read services via `@Environment` instead of .shared. Non-UI call sites (bridge callbacks, AppWindow statics, Haptics, GameLibrary detached tasks) retain .shared because SwiftUI environment isn't reachable from those contexts.