### PR TITLE
refactor: split appstate into crash, logging, termination helpers

### DIFF
--- a/ios/Empo/project.yml
+++ b/ios/Empo/project.yml
@@ -65,6 +65,11 @@ targets:
     platform: iOS
     preBuildScripts:
       - name: Assemble Assets.bundle
+        # Force every build. The script globs the engine's shader/font/
+        # script directories and copies whatever is there, so declaring
+        # a static outputFiles list would drift out of date and silently
+        # drop newly-added assets.
+        basedOnDependencyAnalysis: false
         script: |
           ENGINE="${PROJECT_DIR}/../../mkxp-z-apple-mobile"
           BUNDLE="${PROJECT_DIR}/Assets.bundle"

--- a/ios/Empo/src/App/AppState.swift
+++ b/ios/Empo/src/App/AppState.swift
@@ -15,151 +15,20 @@ class AppState {
     var selectedGame: GameEntry?
     var errorMessage: String?
     var engineReady = false
-    private(set) var pendingCrashRecovery = false
     private var terminationExpected = false
 
-    // When returnToLibrary() asks the engine to terminate, we arm a
-    // watchdog that fires after a few seconds. If the engine-terminated
-    // callback cleared this token by then, the RGSS thread ack'd cleanly
-    // and there is nothing to do. Otherwise the RGSS thread is stuck
-    // and we surface the hang alert immediately - without waiting for
-    // main.cpp's 10s timeout, which would otherwise fire on the NEXT
-    // session's Loading view and confuse the user.
-    private var pendingTerminationToken: UUID?
-    private static let hangWatchdogSeconds: UInt64 = 3
+    private let crashTracker = CrashTracker()
+    private let sessionLogger = SessionLogger()
+    private let termination = EngineTerminationCoordinator()
 
-    // Continuations waiting for the engine-terminated callback to fire,
-    // used by selectGame() to wait for cross-session teardown before
-    // handing the engine a new path. Drained in registerBridgeCallbacks
-    // when the callback runs. No polling, no timeouts - the hang
-    // watchdog above handles the truly-stuck case by force-quitting
-    // the app, which also implicitly drains these (the process exits).
-    private var terminationWaiters: [CheckedContinuation<Void, Never>] = []
+    var pendingCrashRecovery: Bool { crashTracker.pendingCrashRecovery }
 
-    private func awaitEngineTermination() async {
-        // Fast path: engine is already terminated (previous session
-        // finished its cross-session cleanup and is parked in
-        // waitForGamePath) - hand off immediately.
-        if mkxp_isEngineTerminated() != 0 { return }
-        // No termination is in flight - we're on cold boot, the RGSS
-        // thread is waiting for its FIRST game path. Hand off
-        // immediately without parking.
-        if pendingTerminationToken == nil { return }
-        // A termination is actively in flight. Park until the
-        // engine-terminated callback drains our continuation.
-        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-            terminationWaiters.append(cont)
-        }
-    }
-
-    private func drainTerminationWaiters() {
-        let pending = terminationWaiters
-        terminationWaiters.removeAll()
-        for cont in pending { cont.resume() }
-    }
-
-    static let logsDirectory: URL = FileManager.default
-        .urls(for: .documentDirectory, in: .userDomainMask)[0]
-        .appendingPathComponent("Logs", isDirectory: true)
-
-    private let sessionHistoryPath: String
-    private static let isoFormatter = ISO8601DateFormatter()
-    private var sessionStartTime: Date?
-
-    private static let crashMarkerURL: URL = FileManager.default
-        .urls(for: .documentDirectory, in: .userDomainMask)[0]
-        .appendingPathComponent(".session-active")
-
-    /// The crash marker is written each time a game session starts and
-    /// removed when it ends cleanly. If it's still on disk on the
-    /// next app launch, something killed the previous session
-    /// unexpectedly (user-killed-app, OOM, C++ crash).
-    ///
-    /// But reinstalls also leave the marker behind, since the
-    /// Documents directory is preserved across installs. We don't
-    /// want to accuse a fresh install of "not exiting cleanly" when
-    /// the user simply redeployed from Xcode or updated via the App
-    /// Store. Compare the marker's mtime with the executable's
-    /// bundle mtime: if the binary is newer, the marker is stale.
-    private static func isCrashMarkerFromCurrentInstall() -> Bool {
-        let fm = FileManager.default
-        guard fm.fileExists(atPath: crashMarkerURL.path) else { return false }
-
-        guard let markerAttrs = try? fm.attributesOfItem(atPath: crashMarkerURL.path),
-              let markerMtime = markerAttrs[.modificationDate] as? Date else {
-            // Couldn't stat the marker - assume current install so we
-            // don't silently swallow a real crash. Conservative default.
-            return true
-        }
-
-        // Bundle's executable is replaced on every install. Its mtime
-        // is a reliable "install time" proxy across simulators, real
-        // devices, TestFlight, and App Store updates.
-        guard let execPath = Bundle.main.executablePath,
-              let bundleAttrs = try? fm.attributesOfItem(atPath: execPath),
-              let bundleMtime = bundleAttrs[.modificationDate] as? Date else {
-            return true
-        }
-
-        return markerMtime > bundleMtime
-    }
-
-    private static func commitSuffix() -> String {
-        GitInfo.dirty ? " (dirty)" : ""
-    }
-
-    private static func logHeader(title: String, extras: [String] = []) -> String {
-        var header = "\(title)\n"
-        header += "commit: \(GitInfo.commit)\(commitSuffix())\n"
-        for line in extras {
-            header += "\(line)\n"
-        }
-        header += "---\n"
-        return header
-    }
+    /// Preserved as a namespaced alias so call sites outside AppState
+    /// don't reach into SessionLogger directly.
+    static var logsDirectory: URL { SessionLogger.logsDirectory }
 
     private init() {
-        let logsDir = Self.logsDirectory
-        try? FileManager.default.createDirectory(at: logsDir, withIntermediateDirectories: true)
-        sessionHistoryPath = logsDir.appendingPathComponent("session-history.log").path
-
-        let launchTime = Self.isoFormatter.string(from: Date())
-        let header = Self.logHeader(title: "\(AppInfo.name) session history", extras: ["launched: \(launchTime)"])
-        try? header.write(toFile: sessionHistoryPath, atomically: true, encoding: .utf8)
-
-        if Self.isCrashMarkerFromCurrentInstall() {
-            pendingCrashRecovery = true
-        } else {
-            // Stale marker from a previous install (dev redeploy,
-            // TestFlight update, reinstall from App Store). The
-            // session it was recording can't have been in this
-            // binary, so treat the crash state as already resolved
-            // and clean up. Avoids a spurious "didn't exit cleanly"
-            // alert on first launch after a redeploy.
-            try? FileManager.default.removeItem(at: Self.crashMarkerURL)
-        }
-
-        pruneOldLogs(in: logsDir)
         registerBridgeCallbacks()
-    }
-
-    private func pruneOldLogs(in logsDir: URL) {
-        let fm = FileManager.default
-        guard let files = try? fm.contentsOfDirectory(at: logsDir, includingPropertiesForKeys: [.creationDateKey]) else { return }
-
-        let logFiles = files.filter { $0.lastPathComponent != "session-history.log" && $0.pathExtension == "log" }
-        let maxLogFiles = UserDefaults.standard.object(forKey: DefaultsKey.maxLogFiles) as? Int ?? 20
-        guard logFiles.count > maxLogFiles else { return }
-
-        let sorted = logFiles.sorted {
-            let d0 = (try? $0.resourceValues(forKeys: [.creationDateKey]).creationDate) ?? .distantPast
-            let d1 = (try? $1.resourceValues(forKeys: [.creationDateKey]).creationDate) ?? .distantPast
-            return d0 < d1
-        }
-
-        for file in sorted.prefix(sorted.count - maxLogFiles) {
-            try? fm.removeItem(at: file)
-        }
     }
 
 
@@ -187,11 +56,8 @@ class AppState {
         let postload = settings.postloadScripts ?? GameConfigDefaults.enginePostloadScripts
         mkxp_applyPerGameSettings(alignment.bridgeValue, postload)
 
-        FileManager.default.createFile(atPath: Self.crashMarkerURL.path, contents: nil)
-
-        configureDebugLog(for: game)
-        appendSessionHistory(game: game)
-        sessionStartTime = Date()
+        crashTracker.writeMarker()
+        sessionLogger.beginSession(for: game, debugLogsEnabled: AppSettings.shared.debugLogs)
 
         // Wait for the RGSS thread to actually finish tearing down any
         // previous session before we feed it the new path. If we call
@@ -201,92 +67,43 @@ class AppState {
         // waitForGamePath forever.
         //
         // awaitEngineTermination returns immediately when no previous
-        // session is running (isEngineTerminated is already true), and
-        // otherwise parks on a continuation that the engine-terminated
-        // callback wakes up. No polling, no wall-clock deadline: the
-        // hang watchdog in returnToLibrary is what handles a truly
-        // stuck RGSS thread by force-quitting the app.
+        // session is running, and otherwise parks on a continuation
+        // that the engine-terminated callback wakes up. No polling, no
+        // wall-clock deadline: the hang watchdog in returnToLibrary is
+        // what handles a truly stuck RGSS thread by force-quitting the
+        // app.
         //
         // The loading view is already on screen throughout this wait,
         // so it doubles as a "quitting" indicator when the user quickly
         // taps a new game right after quitting.
         Task { @MainActor in
-            await awaitEngineTermination()
+            await termination.awaitEngineTermination()
             mkxp_setGamePath(game.path)
         }
     }
 
-    private func configureDebugLog(for game: GameEntry) {
-        guard AppSettings.shared.debugLogs else {
-            mkxp_setDebugLogPath(nil)
-            return
-        }
-
-        let logsDir = Self.logsDirectory
-        try? FileManager.default.createDirectory(at: logsDir, withIntermediateDirectories: true)
-
-        let slug = game.title
-            .lowercased()
-            .replacingOccurrences(of: "[^a-z0-9]+", with: "-", options: .regularExpression)
-            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
-        let timestamp = Self.isoFormatter.string(from: Date())
-            .replacingOccurrences(of: ":", with: "-")
-        let filename = "\(game.id)-\(slug)-\(timestamp).log"
-        let logPath = logsDir.appendingPathComponent(filename).path
-
-        let header = Self.logHeader(title: "\(AppInfo.name) debug log", extras: [
-            "game: \(game.title) [\(game.id)]",
-            "session: \(timestamp)",
-        ]) + "\n"
-        try? header.write(toFile: logPath, atomically: true, encoding: .utf8)
-
-        mkxp_setDebugLogPath(logPath)
-    }
-
-    private func appendSessionHistory(game: GameEntry) {
-        let timestamp = Self.isoFormatter.string(from: Date())
-        let entry = "\n[\(timestamp)] \(game.title) [\(game.id)]\n"
-        if let data = entry.data(using: .utf8),
-           let fh = FileHandle(forWritingAtPath: sessionHistoryPath) {
-            defer { try? fh.close() }
-            _ = try? fh.seekToEnd()
-            _ = try? fh.write(contentsOf: data)
-        }
-    }
-
     func recordSessionPlayTime() {
-        guard let game = selectedGame,
-              let startTime = sessionStartTime else { return }
-
-        let elapsed = Date().timeIntervalSince(startTime)
-        sessionStartTime = nil
-
-        guard elapsed > 1 else { return }
-
-        var metadata = GameMetadata.load(for: game.id)
-        metadata.totalPlayTime = (metadata.totalPlayTime ?? 0) + elapsed
-        metadata.lastPlayed = Date()
-        metadata.save(for: game.id)
+        sessionLogger.recordSessionPlayTime(for: selectedGame)
     }
 
     private static let crashMessage = "It looks like the game didn't exit cleanly last time. "
         + "Your save data should be fine."
 
     func consumeCrashRecovery() {
-        guard pendingCrashRecovery else { return }
-        pendingCrashRecovery = false
+        guard crashTracker.pendingCrashRecovery else { return }
+        crashTracker.consumeRecovery()
         errorMessage = Self.crashMessage
     }
 
     func dismissCrashRecovery() {
-        removeCrashMarker()
+        crashTracker.removeMarker()
         errorMessage = nil
     }
 
     func returnToLibrary() {
         terminationExpected = true
         recordSessionPlayTime()
-        removeCrashMarker()
+        crashTracker.removeMarker()
 
         // Only talk to the engine if it's still running. After a crash
         // the terminated callback has already fired and re-arming the
@@ -308,58 +125,14 @@ class AppState {
         phase = nil
 
         if engineWasRunning {
-            armHangWatchdog()
+            termination.armHangWatchdog { [weak self] message in
+                self?.errorMessage = message
+            }
         }
     }
 
-    private func armHangWatchdog() {
-        let token = UUID()
-        pendingTerminationToken = token
-        Task { @MainActor [weak self] in
-            try? await Task.sleep(nanoseconds: Self.hangWatchdogSeconds * 1_000_000_000)
-            guard let self else { return }
-            // If the engine-terminated callback already cleared the token
-            // (or replaced it with a newer one), do nothing.
-            guard self.pendingTerminationToken == token else { return }
-            self.pendingTerminationToken = nil
-            // Engine is stuck. Mark the bridge state so the alert's OK
-            // button force-quits, then surface the generic message.
-            mkxp_setEngineHung()
-            self.errorMessage = AppState.hangMessage
-        }
-    }
-
-    private static let hangMessage =
-        "The previous game stopped responding. The app will now close."
-
-    /// Hard-deadline force-quit used by the loading-view escape hatch.
-    ///
-    /// The regular hang watchdog (armHangWatchdog) shows an alert and
-    /// waits for the user to tap OK before calling exit(0). When the
-    /// user tapped "Quit to library" during loading, they're already
-    /// stuck and signaling urgency - making them read and dismiss an
-    /// alert before the app finally closes is bad UX. This helper
-    /// skips the alert entirely and exit(0)s directly after the
-    /// deadline, while still giving the engine a generous window to
-    /// terminate cleanly if it can.
-    ///
-    /// The normal engine-terminated callback path is expected to clear
-    /// `pendingTerminationToken` before the deadline in the happy
-    /// case, which cancels this helper.
     func armLoadingEscapeForceQuit() {
-        let token = pendingTerminationToken
-        Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .seconds(5))
-            guard let self else { return }
-            // Only force-quit if the original termination request the
-            // escape hatch kicked off is still pending (i.e. the engine
-            // never ack'd). Tokens match on reentrant quits too, so a
-            // second tap doesn't double-arm.
-            guard self.pendingTerminationToken == token,
-                  token != nil else { return }
-            mkxp_setEngineHung()
-            exit(0)
-        }
+        termination.armLoadingEscapeForceQuit()
     }
 
 
@@ -417,19 +190,15 @@ class AppState {
     }
 
 
-    private func removeCrashMarker() {
-        try? FileManager.default.removeItem(at: Self.crashMarkerURL)
-    }
-
     /// Remove the crash marker when backgrounding a healthy session.
     /// Re-creates it when the app returns to foreground so a subsequent
     /// crash after resume is still detected.
     func clearCrashMarkerForBackground() {
-        removeCrashMarker()
+        crashTracker.removeMarker()
     }
 
     func restoreCrashMarkerForForeground() {
-        FileManager.default.createFile(atPath: Self.crashMarkerURL.path, contents: nil)
+        crashTracker.writeMarker()
     }
 
     private func registerBridgeCallbacks() {
@@ -450,14 +219,11 @@ class AppState {
         mkxp_setEngineTerminatedCallback({ _ in
             Task { @MainActor in
                 let state = AppState.shared
-                // Engine ack'd termination, so the hang watchdog armed
-                // by returnToLibrary() should not fire.
-                state.pendingTerminationToken = nil
-                // Wake any selectGame awaiters so the pending new
-                // session can hand its path to the RGSS thread.
-                state.drainTerminationWaiters()
+                // Engine ack'd termination: cancel the hang watchdog
+                // and wake selectGame awaiters.
+                state.termination.handleEngineTerminatedAck()
                 state.recordSessionPlayTime()
-                state.removeCrashMarker()
+                state.crashTracker.removeMarker()
                 GameLibrary.shared.reload()
 
                 if !state.terminationExpected && state.phase != nil {
@@ -498,7 +264,7 @@ class AppState {
             }
         }, nil)
 
-        // Engine paused - capture snapshot while lock is held.
+        // Engine paused — capture snapshot while lock is held.
         mkxp_setPausedCallback({ _ in
             var snapshotImage: UIImage?
             var w: Int32 = 0

--- a/ios/Empo/src/App/CrashTracker.swift
+++ b/ios/Empo/src/App/CrashTracker.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Tracks unclean engine terminations via a marker file in Documents.
+///
+/// Each game session writes the marker on start and removes it on clean
+/// exit. If it's still present on next launch, the previous session died
+/// unexpectedly (user force-kill, OOM, C++ crash) — unless the binary was
+/// replaced in the meantime (redeploy, TestFlight update, App Store update),
+/// in which case the marker belongs to a prior install and is discarded.
+@MainActor
+final class CrashTracker {
+    private static let markerURL: URL = FileManager.default
+        .urls(for: .documentDirectory, in: .userDomainMask)[0]
+        .appendingPathComponent(".session-active")
+
+    /// True iff a marker from THIS install was found at launch.
+    /// Flipped to false once `consumeRecovery()` has run so repeated
+    /// checks after handling the alert don't re-trigger.
+    private(set) var pendingCrashRecovery: Bool
+
+    init() {
+        if Self.isMarkerFromCurrentInstall() {
+            pendingCrashRecovery = true
+        } else {
+            // Stale marker from a previous install. The session it
+            // recorded can't have been in this binary, so treat the
+            // crash state as already resolved and clean up. Avoids a
+            // spurious "didn't exit cleanly" alert on first launch
+            // after a redeploy.
+            try? FileManager.default.removeItem(at: Self.markerURL)
+            pendingCrashRecovery = false
+        }
+    }
+
+    /// Marks the pending recovery as handled. Call once the UI has
+    /// surfaced the alert so subsequent reads see false.
+    func consumeRecovery() {
+        pendingCrashRecovery = false
+    }
+
+    func writeMarker() {
+        FileManager.default.createFile(atPath: Self.markerURL.path, contents: nil)
+    }
+
+    func removeMarker() {
+        try? FileManager.default.removeItem(at: Self.markerURL)
+    }
+
+    /// Compare the marker's mtime with the executable's bundle mtime.
+    /// The bundle executable is replaced on every install, so its
+    /// mtime is a reliable install-time proxy across simulators, real
+    /// devices, TestFlight, and App Store updates.
+    private static func isMarkerFromCurrentInstall() -> Bool {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: markerURL.path) else { return false }
+
+        guard let markerAttrs = try? fm.attributesOfItem(atPath: markerURL.path),
+              let markerMtime = markerAttrs[.modificationDate] as? Date else {
+            // Couldn't stat the marker — assume current install so we
+            // don't silently swallow a real crash. Conservative default.
+            return true
+        }
+
+        guard let execPath = Bundle.main.executablePath,
+              let bundleAttrs = try? fm.attributesOfItem(atPath: execPath),
+              let bundleMtime = bundleAttrs[.modificationDate] as? Date else {
+            return true
+        }
+
+        return markerMtime > bundleMtime
+    }
+}

--- a/ios/Empo/src/App/EngineTerminationCoordinator.swift
+++ b/ios/Empo/src/App/EngineTerminationCoordinator.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// Coordinates RGSS engine-thread termination handshakes so `selectGame`
+/// doesn't race new sessions against still-terminating ones, and surfaces
+/// a hang dialog (or force-quits) when the engine never ack's.
+///
+/// Usage pattern:
+/// - `returnToLibrary()` calls `armHangWatchdog { msg in state.errorMessage = msg }`.
+/// - The bridge's engine-terminated callback calls `handleEngineTerminatedAck()` to cancel the watchdog and drain any pending `selectGame` awaiter.
+/// - `selectGame` calls `awaitEngineTermination()` before handing the new game path to the RGSS thread.
+@MainActor
+final class EngineTerminationCoordinator {
+    static let hangMessage =
+        "The previous game stopped responding. The app will now close."
+
+    private static let hangWatchdogSeconds: UInt64 = 3
+
+    // When returnToLibrary() asks the engine to terminate, we arm a
+    // watchdog that fires after a few seconds. If the engine-terminated
+    // callback clears this token by then, the RGSS thread ack'd cleanly
+    // and there's nothing to do. Otherwise the RGSS thread is stuck and
+    // we surface the hang alert immediately — without waiting for
+    // main.cpp's 10s timeout, which would otherwise fire on the NEXT
+    // session's Loading view and confuse the user.
+    private var pendingToken: UUID?
+
+    // Continuations waiting for the engine-terminated callback to fire,
+    // used by selectGame() to wait for cross-session teardown before
+    // handing the engine a new path. Drained in handleEngineTerminatedAck
+    // when the callback runs. No polling, no timeouts — the hang
+    // watchdog above handles the truly-stuck case by force-quitting
+    // the app, which also implicitly drains these (the process exits).
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func awaitEngineTermination() async {
+        // Fast path: engine is already terminated (previous session
+        // finished its cross-session cleanup and is parked in
+        // waitForGamePath) — hand off immediately.
+        if mkxp_isEngineTerminated() != 0 { return }
+        // No termination is in flight — we're on cold boot, the RGSS
+        // thread is waiting for its FIRST game path. Hand off
+        // immediately without parking.
+        if pendingToken == nil { return }
+        // A termination is actively in flight. Park until the
+        // engine-terminated callback drains our continuation.
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            waiters.append(cont)
+        }
+    }
+
+    /// Called by the bridge's engine-terminated callback. Cancels any
+    /// armed watchdog and wakes selectGame awaiters so the pending new
+    /// session can hand its path to the RGSS thread.
+    func handleEngineTerminatedAck() {
+        pendingToken = nil
+        let pending = waiters
+        waiters.removeAll()
+        for cont in pending { cont.resume() }
+    }
+
+    /// Arms a one-shot timer: if the engine hasn't ack'd termination
+    /// within `hangWatchdogSeconds`, invoke `onHang` with a user-facing
+    /// message and mark the bridge as hung.
+    func armHangWatchdog(onHang: @escaping @MainActor (String) -> Void) {
+        let token = UUID()
+        pendingToken = token
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: Self.hangWatchdogSeconds * 1_000_000_000)
+            guard let self, self.pendingToken == token else { return }
+            self.pendingToken = nil
+            mkxp_setEngineHung()
+            onHang(Self.hangMessage)
+        }
+    }
+
+    /// Hard-deadline force-quit used by the loading-view escape hatch.
+    ///
+    /// The regular hang watchdog shows an alert and waits for the user
+    /// to tap OK before calling exit(0). When the user tapped "Quit to
+    /// library" during loading, they're already stuck and signaling
+    /// urgency — making them read and dismiss an alert before the app
+    /// finally closes is bad UX. This helper skips the alert entirely
+    /// and exit(0)s directly after the deadline, while still giving the
+    /// engine a generous window to terminate cleanly if it can.
+    ///
+    /// The normal engine-terminated callback path is expected to clear
+    /// `pendingToken` before the deadline in the happy case, which
+    /// cancels this helper.
+    func armLoadingEscapeForceQuit() {
+        let token = pendingToken
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(5))
+            guard let self,
+                  self.pendingToken == token,
+                  token != nil else { return }
+            mkxp_setEngineHung()
+            exit(0)
+        }
+    }
+}

--- a/ios/Empo/src/App/SessionLogger.swift
+++ b/ios/Empo/src/App/SessionLogger.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+/// Owns the logs/ directory: writes the per-launch session-history
+/// file, configures per-game debug log paths, appends history entries,
+/// records play time on session end, and prunes old logs.
+@MainActor
+final class SessionLogger {
+    static let logsDirectory: URL = FileManager.default
+        .urls(for: .documentDirectory, in: .userDomainMask)[0]
+        .appendingPathComponent("Logs", isDirectory: true)
+
+    private static let isoFormatter = ISO8601DateFormatter()
+
+    private let sessionHistoryPath: String
+    private var sessionStartTime: Date?
+
+    init() {
+        let logsDir = Self.logsDirectory
+        try? FileManager.default.createDirectory(at: logsDir, withIntermediateDirectories: true)
+        sessionHistoryPath = logsDir.appendingPathComponent("session-history.log").path
+
+        let launchTime = Self.isoFormatter.string(from: Date())
+        let header = Self.logHeader(title: "\(AppInfo.name) session history", extras: ["launched: \(launchTime)"])
+        try? header.write(toFile: sessionHistoryPath, atomically: true, encoding: .utf8)
+
+        pruneOldLogs(in: logsDir)
+    }
+
+    func beginSession(for game: GameEntry, debugLogsEnabled: Bool) {
+        configureDebugLog(for: game, enabled: debugLogsEnabled)
+        appendSessionHistory(game: game)
+        sessionStartTime = Date()
+    }
+
+    /// Persists accumulated play time into the game's metadata.
+    /// Safe to call when no session is active (no-op).
+    func recordSessionPlayTime(for game: GameEntry?) {
+        guard let game, let startTime = sessionStartTime else { return }
+        let elapsed = Date().timeIntervalSince(startTime)
+        sessionStartTime = nil
+        guard elapsed > 1 else { return }
+
+        var metadata = GameMetadata.load(for: game.id)
+        metadata.totalPlayTime = (metadata.totalPlayTime ?? 0) + elapsed
+        metadata.lastPlayed = Date()
+        metadata.save(for: game.id)
+    }
+
+    private func configureDebugLog(for game: GameEntry, enabled: Bool) {
+        guard enabled else {
+            mkxp_setDebugLogPath(nil)
+            return
+        }
+
+        let logsDir = Self.logsDirectory
+        try? FileManager.default.createDirectory(at: logsDir, withIntermediateDirectories: true)
+
+        let slug = game.title
+            .lowercased()
+            .replacingOccurrences(of: "[^a-z0-9]+", with: "-", options: .regularExpression)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        let timestamp = Self.isoFormatter.string(from: Date())
+            .replacingOccurrences(of: ":", with: "-")
+        let filename = "\(game.id)-\(slug)-\(timestamp).log"
+        let logPath = logsDir.appendingPathComponent(filename).path
+
+        let header = Self.logHeader(title: "\(AppInfo.name) debug log", extras: [
+            "game: \(game.title) [\(game.id)]",
+            "session: \(timestamp)",
+        ]) + "\n"
+        try? header.write(toFile: logPath, atomically: true, encoding: .utf8)
+
+        mkxp_setDebugLogPath(logPath)
+    }
+
+    private func appendSessionHistory(game: GameEntry) {
+        let timestamp = Self.isoFormatter.string(from: Date())
+        let entry = "\n[\(timestamp)] \(game.title) [\(game.id)]\n"
+        if let data = entry.data(using: .utf8),
+           let fh = FileHandle(forWritingAtPath: sessionHistoryPath) {
+            defer { try? fh.close() }
+            _ = try? fh.seekToEnd()
+            _ = try? fh.write(contentsOf: data)
+        }
+    }
+
+    private func pruneOldLogs(in logsDir: URL) {
+        let fm = FileManager.default
+        guard let files = try? fm.contentsOfDirectory(at: logsDir, includingPropertiesForKeys: [.creationDateKey]) else { return }
+
+        let logFiles = files.filter { $0.lastPathComponent != "session-history.log" && $0.pathExtension == "log" }
+        let maxLogFiles = UserDefaults.standard.object(forKey: DefaultsKey.maxLogFiles) as? Int ?? 20
+        guard logFiles.count > maxLogFiles else { return }
+
+        let sorted = logFiles.sorted {
+            let d0 = (try? $0.resourceValues(forKeys: [.creationDateKey]).creationDate) ?? .distantPast
+            let d1 = (try? $1.resourceValues(forKeys: [.creationDateKey]).creationDate) ?? .distantPast
+            return d0 < d1
+        }
+
+        for file in sorted.prefix(sorted.count - maxLogFiles) {
+            try? fm.removeItem(at: file)
+        }
+    }
+
+    private static func commitSuffix() -> String {
+        GitInfo.dirty ? " (dirty)" : ""
+    }
+
+    private static func logHeader(title: String, extras: [String] = []) -> String {
+        var header = "\(title)\n"
+        header += "commit: \(GitInfo.commit)\(commitSuffix())\n"
+        for line in extras {
+            header += "\(line)\n"
+        }
+        header += "---\n"
+        return header
+    }
+}


### PR DESCRIPTION
Tier 3a of audit roadmap. Splits AppState's three distinct concerns into focused helpers:

- CrashTracker: marker file I/O, isFromCurrentInstall, pendingCrashRecovery flag
- SessionLogger: logs dir, per-launch history, per-game debug log config, play time recording, old-log pruning
- EngineTerminationCoordinator: termination watchdog, awaitEngineTermination, handleEngineTerminatedAck, loading escape force-quit

AppState shrinks from 535 to 303 lines and now just owns phase/selectedGame/errorMessage/engineReady, pause lifecycle, game selection, return-to-library, and bridge callback registration.

Also silences the pre-existing 'Assemble Assets.bundle will run every build' warning by marking basedOnDependencyAnalysis: false explicitly (matches the Generate Git Info phase pattern).