### PR TITLE
refactor: split playerview into geometry, toolbar, controls overlay

### DIFF
--- a/ios/Empo/src/Player/ControlsZoneGeometry.swift
+++ b/ios/Empo/src/Player/ControlsZoneGeometry.swift
@@ -1,0 +1,134 @@
+import SwiftUI
+import UIKit
+
+/// Pure geometry helpers for placing on-screen controls. Lifted out of
+/// PlayerView so the layout math is testable / diffable in isolation
+/// and PlayerView stays focused on state + view composition.
+
+enum ControlsZone {
+    static let padding: CGFloat = 12.0
+    static let innerPadding: CGFloat = 6.0
+    static let toolbarGap: CGFloat = 8.0
+    static let toolbarEdgePad: CGFloat = 4.0
+    static let editToolbarHalfHeight: CGFloat = 20.0
+    static let minLandscapeInset: CGFloat = 12.0
+    static let fallbackDeviceCornerRadius: CGFloat = 55.0
+    static let dragScaleFactor: CGFloat = 1.08
+
+    /// Minimum vertical space below the game rect required to place
+    /// the toolbar + controls in the dedicated zone below the game.
+    /// When the game fills most of the screen (fixedAspectRatio off)
+    /// there isn't enough room, so we fall back to overlay mode (same
+    /// as landscape: toolbar at top, controls over the game).
+    static let minControlsZoneHeight: CGFloat = 120
+
+    static func bounds(controlsMinY: CGFloat, safeArea: EdgeInsets, geoSize: CGSize) -> CGRect {
+        let pad = padding
+        let top = controlsMinY + pad
+        let bottom = geoSize.height - safeArea.bottom - pad
+        let leading = safeArea.leading + pad
+        let trailing = geoSize.width - safeArea.trailing - pad
+        return CGRect(x: leading, y: top, width: trailing - leading, height: bottom - top)
+    }
+
+    static func cornerRadii(safeArea: EdgeInsets) -> (top: CGFloat, bottom: CGFloat) {
+        let pad = padding
+        let screen = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first?.screen
+        let deviceCorner = (screen?.value(forKey: "displayCornerRadius") as? CGFloat) ?? fallbackDeviceCornerRadius
+        let horizontalGap = safeArea.leading + pad
+        let bottomGap = safeArea.bottom + pad
+        let minGap = min(horizontalGap, bottomGap)
+        let bottom = max(deviceCorner - minGap, Radius.sm)
+        let top = Radius.xl
+        return (top, bottom)
+    }
+
+    static func useOverlayLayout(isPortrait: Bool, gameRect: CGRect, safeArea: EdgeInsets, geoHeight: CGFloat) -> Bool {
+        guard isPortrait, gameRect.height > 0 else { return false }
+        let spaceBelow = geoHeight - (gameRect.origin.y + gameRect.height) - safeArea.bottom
+        return spaceBelow < minControlsZoneHeight
+    }
+
+    /// Top edge of the controls zone: controls can only live below
+    /// this Y. In portrait with space below the game, the zone begins
+    /// right at the game's bottom edge (toolbar is now at the top so
+    /// it doesn't push controls down). In overlay / landscape, the
+    /// zone begins below the toolbar that sits in the top-right.
+    static func toolbarBottomY(isPortrait: Bool, gameRect: CGRect, safeArea: EdgeInsets, btnSize: CGFloat, geoHeight: CGFloat) -> CGFloat {
+        if isPortrait && gameRect.height > 0 && !useOverlayLayout(isPortrait: isPortrait, gameRect: gameRect, safeArea: safeArea, geoHeight: geoHeight) {
+            return gameRect.origin.y + gameRect.height + toolbarGap
+        } else {
+            let topInset = max(safeArea.top, minLandscapeInset)
+            return topInset + toolbarEdgePad + btnSize + toolbarEdgePad
+        }
+    }
+
+    /// Always anchor the toolbar to the top-right of the device
+    /// viewport. In portrait we used to tuck it below the game rect,
+    /// which left the keyboard-toggle button covered by the keyboard
+    /// whenever it was up. Placing it at the top keeps it reachable
+    /// in every orientation + layout mode.
+    static func toolbarOrigin(safeArea: EdgeInsets, geoSize: CGSize, btnSize: CGFloat, gap: CGFloat, count: CGFloat) -> CGPoint {
+        let totalW = count * btnSize + (count - 1) * gap
+        let rightInset = max(safeArea.trailing, minLandscapeInset)
+        let topInset = max(safeArea.top, minLandscapeInset)
+        let x = geoSize.width - rightInset - toolbarEdgePad - totalW / 2
+        let y = topInset + toolbarEdgePad + btnSize / 2
+        return CGPoint(x: x, y: y)
+    }
+
+    static func absolutePosition(for relativeCenter: CGPoint, in size: CGSize, controlSize: CGSize, safeArea: EdgeInsets, controlsMinY: CGFloat) -> CGPoint {
+        let pad = padding + innerPadding
+        let hw = controlSize.width * 0.5
+        let hh = controlSize.height * 0.5
+        let minX = safeArea.leading + pad + hw
+        let minY = max(safeArea.top + pad + hh, controlsMinY + pad + hh)
+        let maxX = size.width - safeArea.trailing - pad - hw
+        let maxY = size.height - safeArea.bottom - pad - hh
+        let cx = max(minX, min(relativeCenter.x * size.width, maxX))
+        let cy = max(minY, min(relativeCenter.y * size.height, maxY))
+        let zone = bounds(controlsMinY: controlsMinY, safeArea: safeArea, geoSize: size)
+        let radii = cornerRadii(safeArea: safeArea)
+        return clampToRoundedCorners(CGPoint(x: cx, y: cy), controlHalf: max(hw, hh), zone: zone, radii: radii)
+    }
+
+    static func clampToSafeArea(_ point: CGPoint, controlSize: CGFloat, geoSize: CGSize, safeArea: EdgeInsets, controlsMinY: CGFloat) -> CGPoint {
+        let pad = padding + innerPadding
+        let hw = controlSize * 0.5
+        let x = max(safeArea.leading + pad + hw, min(point.x, geoSize.width - safeArea.trailing - pad - hw))
+        let minY = max(safeArea.top + pad + hw, controlsMinY + pad + hw)
+        let y = max(minY, min(point.y, geoSize.height - safeArea.bottom - pad - hw))
+        let zone = bounds(controlsMinY: controlsMinY, safeArea: safeArea, geoSize: geoSize)
+        let radii = cornerRadii(safeArea: safeArea)
+        return clampToRoundedCorners(CGPoint(x: x, y: y), controlHalf: hw, zone: zone, radii: radii)
+    }
+
+    static func clampToRoundedCorners(_ point: CGPoint, controlHalf: CGFloat, zone: CGRect, radii: (top: CGFloat, bottom: CGFloat)) -> CGPoint {
+        var p = point
+        let corners: [(cx: CGFloat, cy: CGFloat, r: CGFloat)] = [
+            (zone.minX + radii.top, zone.minY + radii.top, radii.top),
+            (zone.maxX - radii.top, zone.minY + radii.top, radii.top),
+            (zone.minX + radii.bottom, zone.maxY - radii.bottom, radii.bottom),
+            (zone.maxX - radii.bottom, zone.maxY - radii.bottom, radii.bottom),
+        ]
+        for corner in corners {
+            let inCornerX = (p.x < corner.cx && corner.cx <= zone.minX + max(radii.top, radii.bottom))
+                         || (p.x > corner.cx && corner.cx >= zone.maxX - max(radii.top, radii.bottom))
+            let inCornerY = (p.y < corner.cy && corner.cy <= zone.minY + max(radii.top, radii.bottom))
+                         || (p.y > corner.cy && corner.cy >= zone.maxY - max(radii.top, radii.bottom))
+            guard inCornerX && inCornerY else { continue }
+            let dx = p.x - corner.cx
+            let dy = p.y - corner.cy
+            let dist = sqrt(dx * dx + dy * dy)
+            let maxDist = corner.r - controlHalf - innerPadding
+            if maxDist > 0 && dist > maxDist {
+                let scale = maxDist / dist
+                p.x = corner.cx + dx * scale
+                p.y = corner.cy + dy * scale
+            }
+        }
+        return p
+    }
+}

--- a/ios/Empo/src/Player/PlayerControlsOverlay.swift
+++ b/ios/Empo/src/Player/PlayerControlsOverlay.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+
+/// D-pad + action buttons layer. Rendering, drag gestures, and edit
+/// affordances (tap-to-edit, delete chip, drag scale) live here so
+/// PlayerView only has to toggle visibility and own the edit state
+/// that the edit dialogs consume.
+
+struct PlayerControlsOverlay: View {
+    @Bindable var layout: ControlsLayout
+    let geo: GeometryProxy
+    let controlsMinY: CGFloat
+    let editMode: Bool
+    @Binding var editingButton: ButtonModel?
+    @Binding var editingDPad: Bool
+    @Binding var draggingDPad: Bool
+    @Binding var draggingButtonID: UUID?
+
+    var body: some View {
+        ZStack {
+            dpadView
+            ForEach(Array(layout.buttons.enumerated()), id: \.element.id) { index, button in
+                actionButton(button: button, index: index)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var dpadView: some View {
+        let size = layout.dpadSize
+        let pos = ControlsZone.absolutePosition(for: layout.dpadRelativeCenter, in: geo.size, controlSize: CGSize(width: size, height: size), safeArea: AppWindow.currentSafeArea, controlsMinY: controlsMinY)
+        let anchor = UnitPoint(x: pos.x / geo.size.width, y: pos.y / geo.size.height)
+        DPad(size: size, editing: editMode)
+            .frame(width: size, height: size)
+            .opacity(layout.dpadOpacity)
+            .scaleEffect(draggingDPad ? ControlsZone.dragScaleFactor : 1.0)
+            .animation(Motion.snappy, value: draggingDPad)
+            .position(pos)
+            .transition(.controlAppear(anchor: anchor))
+            // Tap-to-edit only fires in edit mode. Tapping the D-pad
+            // during normal play falls through to the DPad's own
+            // gesture for direction input.
+            .onTapGesture {
+                guard editMode else { return }
+                editingDPad = true
+            }
+            .gesture(dpadDragGesture, including: editMode ? .all : .none)
+    }
+
+    private var dpadDragGesture: some Gesture {
+        DragGesture()
+            .onChanged { value in
+                if !draggingDPad { draggingDPad = true }
+                let clamped = ControlsZone.clampToSafeArea(value.location, controlSize: layout.dpadSize, geoSize: geo.size, safeArea: AppWindow.currentSafeArea, controlsMinY: controlsMinY)
+                layout.dpadRelativeCenter = CGPoint(
+                    x: clamped.x / geo.size.width,
+                    y: clamped.y / geo.size.height
+                )
+            }
+            .onEnded { _ in
+                draggingDPad = false
+                layout.save()
+            }
+    }
+
+    @ViewBuilder
+    private func actionButton(button: ButtonModel, index: Int) -> some View {
+        let pos = ControlsZone.absolutePosition(for: button.relativeCenter, in: geo.size, controlSize: CGSize(width: button.size, height: button.size), safeArea: AppWindow.currentSafeArea, controlsMinY: controlsMinY)
+        let isDragging = draggingButtonID == button.id
+        let anchor = UnitPoint(x: pos.x / geo.size.width, y: pos.y / geo.size.height)
+        ActionButton(
+            label: button.label,
+            scancode: button.scancode,
+            size: button.size,
+            editing: editMode
+        )
+        .frame(width: button.size, height: button.size)
+        .opacity(button.opacity)
+        .onTapGesture {
+            guard editMode else { return }
+            editingButton = button
+        }
+        .overlay(alignment: .topTrailing) {
+            if editMode && !isDragging {
+                Button {
+                    withAnimation(Motion.snappy) {
+                        layout.removeButton(id: button.id)
+                    }
+                } label: {
+                    Chip(systemImage: "xmark", tint: .destructive)
+                }
+                .transition(.scale.combined(with: .opacity))
+            }
+        }
+        .scaleEffect(isDragging ? ControlsZone.dragScaleFactor : 1.0)
+        .animation(Motion.snappy, value: isDragging)
+        .position(pos)
+        .transition(.controlAppear(anchor: anchor))
+        .gesture(buttonDragGesture(id: button.id, size: button.size), including: editMode ? .all : .none)
+    }
+
+    private func buttonDragGesture(id: UUID, size: CGFloat) -> some Gesture {
+        DragGesture()
+            .onChanged { value in
+                if draggingButtonID != id { draggingButtonID = id }
+                let clamped = ControlsZone.clampToSafeArea(value.location, controlSize: size, geoSize: geo.size, safeArea: AppWindow.currentSafeArea, controlsMinY: controlsMinY)
+                layout.updateButton(id: id, relativeCenter: CGPoint(
+                    x: clamped.x / geo.size.width,
+                    y: clamped.y / geo.size.height
+                ))
+            }
+            .onEnded { _ in
+                draggingButtonID = nil
+                layout.save()
+            }
+    }
+}

--- a/ios/Empo/src/Player/PlayerToolbar.swift
+++ b/ios/Empo/src/Player/PlayerToolbar.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+
+/// Top-right toolbar overlay shown during play. Kept as a standalone
+/// View so PlayerView can focus on orchestration (state, lifecycle,
+/// alerts) while toolbar assembly + edit-mode variant live here.
+
+struct PlayerToolbar: View {
+    let isPortrait: Bool
+    let safeArea: EdgeInsets
+    let geoSize: CGSize
+    let controlsHidden: Bool
+    let toolbarOpacity: Double
+    @Binding var showQuitConfirm: Bool
+    @Binding var showDebugOverlay: Bool
+    let onToggleKeyboard: () -> Void
+    let onToggleEditMode: () -> Void
+    let onToggleHideControls: () -> Void
+    let onRequestPause: () -> Void
+    let onResetIdleTimer: () -> Void
+    @Environment(\.appSettings) private var settings
+
+    var body: some View {
+        let btnSize = IconButtonSize.sm.points
+        let gap: CGFloat = isPortrait ? Spacing.sm : Spacing.md
+
+        let buttons: [ToolbarEntry] = {
+            var list: [ToolbarEntry] = []
+            if settings.isEnabled(.gamePause) {
+                list.append(ToolbarEntry(icon: "pause.fill", label: "Pause game", tint: .white, action: onRequestPause))
+            }
+            list.append(ToolbarEntry(icon: "keyboard", label: "Toggle keyboard", tint: .white, action: onToggleKeyboard))
+            if settings.debugMode {
+                list.append(ToolbarEntry(icon: "chart.line.uptrend.xyaxis", label: "Debug overlay", tint: .white, action: { showDebugOverlay.toggle() }))
+            }
+            list.append(ToolbarEntry(icon: "gearshape.fill", label: "Edit controls", tint: .white, action: onToggleEditMode))
+            list.append(ToolbarEntry(
+                icon: controlsHidden ? "eye.slash.fill" : "eye.fill",
+                label: controlsHidden ? "Show controls" : "Hide controls",
+                tint: .white,
+                action: onToggleHideControls
+            ))
+            if settings.isEnabled(.gameQuit) {
+                list.append(ToolbarEntry(icon: "xmark.circle.fill", label: "Quit game", tint: .destructive, action: { showQuitConfirm = true }))
+            }
+            return list
+        }()
+
+        let toolbarPosition = ControlsZone.toolbarOrigin(safeArea: safeArea, geoSize: geoSize, btnSize: btnSize, gap: gap, count: CGFloat(buttons.count))
+
+        HStack(spacing: gap) {
+            ForEach(Array(buttons.enumerated()), id: \.offset) { _, entry in
+                IconButton(
+                    entry.icon,
+                    style: .outline,
+                    size: IconButtonSize.sm,
+                    tint: entry.tint
+                ) {
+                    onResetIdleTimer()
+                    entry.action()
+                }
+                .accessibilityLabel(entry.label)
+            }
+        }
+        // Pin the Liquid Glass material to the dark variant so the
+        // toolbar matches the on-screen controls (D-pad, action
+        // buttons) and doesn't shift appearance with the system
+        // color scheme or the backdrop brightness of the game.
+        .darkGlass()
+        .opacity(toolbarOpacity)
+        .position(toolbarPosition)
+    }
+
+    private struct ToolbarEntry {
+        let icon: String
+        let label: String
+        let tint: Color?
+        let action: () -> Void
+    }
+}
+
+
+struct PlayerEditToolbar: View {
+    let isPortrait: Bool
+    let gameRect: CGRect
+    let safeArea: EdgeInsets
+    let geoSize: CGSize
+    @Binding var showAddSheet: Bool
+    @Binding var showResetConfirm: Bool
+    let onDone: () -> Void
+
+    var body: some View {
+        let overlay = ControlsZone.useOverlayLayout(isPortrait: isPortrait, gameRect: gameRect, safeArea: safeArea, geoHeight: geoSize.height)
+        let yPos: CGFloat = isPortrait && gameRect.height > 0 && !overlay
+            ? gameRect.origin.y + gameRect.height + ControlsZone.toolbarGap + ControlsZone.editToolbarHalfHeight
+            : max(safeArea.top, ControlsZone.minLandscapeInset) + ControlsZone.toolbarEdgePad + ControlsZone.editToolbarHalfHeight
+
+        HStack(spacing: Spacing.xl) {
+            Button("+ Add") { showAddSheet = true }
+                .accessibilityLabel("Add button")
+                .foregroundStyle(.white)
+                .font(.footnote.weight(.semibold))
+            Button("Reset") { showResetConfirm = true }
+                .foregroundStyle(.brand)
+                .font(.footnote.weight(.semibold))
+            Button("Done") { onDone() }
+                .foregroundStyle(.success)
+                .font(.footnote.weight(.bold))
+        }
+        .padding(.horizontal, Spacing.xl)
+        .padding(.vertical, Spacing.sm)
+        .background(Color.black.opacity(Overlay.heavy))
+        .clipShape(RoundedRectangle(cornerRadius: Radius.md))
+        .position(x: geoSize.width / 2, y: yPos)
+    }
+}

--- a/ios/Empo/src/Player/PlayerView.swift
+++ b/ios/Empo/src/Player/PlayerView.swift
@@ -2,14 +2,6 @@ import SwiftUI
 
 
 private let kToolbarIdleDelay: TimeInterval = 3.0
-private let kControlsZonePadding: CGFloat = 12.0
-private let kControlsZoneInnerPadding: CGFloat = 6.0
-private let kToolbarGap: CGFloat = 8.0
-private let kToolbarEdgePad: CGFloat = 4.0
-private let kEditToolbarHalfHeight: CGFloat = 20.0
-private let kMinLandscapeInset: CGFloat = 12.0
-private let kFallbackDeviceCornerRadius: CGFloat = 55.0
-private let kDragScaleFactor: CGFloat = 1.08
 
 
 struct PlayerView: View {
@@ -50,13 +42,12 @@ struct PlayerView: View {
             let isPortrait = geo.size.height > geo.size.width
             let gameRect = engineState.gameRect
             let safeArea = AppWindow.currentSafeArea
-            let overlay = useOverlayLayout(isPortrait: isPortrait, gameRect: gameRect, safeArea: safeArea, geoHeight: geo.size.height)
             // Toolbar sits at the top-right of the device in every
             // layout, so the portrait-specific size reduction (used when
             // the toolbar was cramped in the zone below the game) no
             // longer applies.
             let toolbarBtnSize = IconButtonSize.sm.points
-            let controlsMinY = toolbarBottomY(isPortrait: isPortrait, gameRect: gameRect, safeArea: safeArea, btnSize: toolbarBtnSize, geoHeight: geo.size.height)
+            let controlsMinY = ControlsZone.toolbarBottomY(isPortrait: isPortrait, gameRect: gameRect, safeArea: safeArea, btnSize: toolbarBtnSize, geoHeight: geo.size.height)
 
             ZStack {
                 if editMode {
@@ -78,20 +69,47 @@ struct PlayerView: View {
                 }
 
                 if !controlsHidden && controlsVisible {
-                    dpadView(in: geo, controlsMinY: controlsMinY)
-
-                    ForEach(Array(layout.buttons.enumerated()), id: \.element.id) { index, button in
-                        actionButtonView(button: button, index: index, in: geo, controlsMinY: controlsMinY)
-                    }
+                    PlayerControlsOverlay(
+                        layout: layout,
+                        geo: geo,
+                        controlsMinY: controlsMinY,
+                        editMode: editMode,
+                        editingButton: $editingButton,
+                        editingDPad: $editingDPad,
+                        draggingDPad: $draggingDPad,
+                        draggingButtonID: $draggingButtonID
+                    )
                 }
 
                 if controlsVisible {
-                    toolbarButtons(isPortrait: isPortrait, gameRect: gameRect, safeArea: safeArea, geoSize: geo.size)
-                        .opacity(editMode ? 0 : 1)
-                        .allowsHitTesting(!editMode)
-                    editToolbar(isPortrait: isPortrait, gameRect: gameRect, safeArea: safeArea, geoSize: geo.size)
-                        .opacity(editMode ? 1 : 0)
-                        .allowsHitTesting(editMode)
+                    PlayerToolbar(
+                        isPortrait: isPortrait,
+                        safeArea: safeArea,
+                        geoSize: geo.size,
+                        controlsHidden: controlsHidden,
+                        toolbarOpacity: toolbarOpacity,
+                        showQuitConfirm: $showQuitConfirm,
+                        showDebugOverlay: $showDebugOverlay,
+                        onToggleKeyboard: { toggleKeyboard() },
+                        onToggleEditMode: { toggleEditMode() },
+                        onToggleHideControls: { toggleHideControls() },
+                        onRequestPause: { appState.requestPause() },
+                        onResetIdleTimer: { resetToolbarIdleTimer() }
+                    )
+                    .opacity(editMode ? 0 : 1)
+                    .allowsHitTesting(!editMode)
+
+                    PlayerEditToolbar(
+                        isPortrait: isPortrait,
+                        gameRect: gameRect,
+                        safeArea: safeArea,
+                        geoSize: geo.size,
+                        showAddSheet: $showAddSheet,
+                        showResetConfirm: $showResetConfirm,
+                        onDone: { toggleEditMode() }
+                    )
+                    .opacity(editMode ? 1 : 0)
+                    .allowsHitTesting(editMode)
                 }
 
                 DraggableDebugOverlay(
@@ -101,7 +119,7 @@ struct PlayerView: View {
                     gameRect: gameRect,
                     safeArea: safeArea,
                     geoSize: geo.size,
-                    useOverlayLayout: useOverlayLayout(
+                    useOverlayLayout: ControlsZone.useOverlayLayout(
                         isPortrait: isPortrait,
                         gameRect: gameRect,
                         safeArea: safeArea,
@@ -178,178 +196,9 @@ struct PlayerView: View {
 
 
     @ViewBuilder
-    private func dpadView(in geo: GeometryProxy, controlsMinY: CGFloat) -> some View {
-        let size = layout.dpadSize
-        let pos = absolutePosition(for: layout.dpadRelativeCenter, in: geo.size, controlSize: CGSize(width: size, height: size), safeArea: AppWindow.currentSafeArea, controlsMinY: controlsMinY)
-        let anchor = UnitPoint(x: pos.x / geo.size.width, y: pos.y / geo.size.height)
-        DPad(size: size, editing: editMode)
-            .frame(width: size, height: size)
-            .opacity(layout.dpadOpacity)
-            .scaleEffect(draggingDPad ? kDragScaleFactor : 1.0)
-            .animation(Motion.snappy, value: draggingDPad)
-            .position(pos)
-            .transition(.controlAppear(anchor: anchor))
-            // Tap-to-edit only fires in edit mode. Tapping the D-pad
-            // during normal play falls through to the DPad's own
-            // gesture for direction input.
-            .onTapGesture {
-                guard editMode else { return }
-                editingDPad = true
-            }
-            .gesture(dpadDragGesture(in: geo, controlsMinY: controlsMinY), including: editMode ? .all : .none)
-    }
-
-    private func dpadDragGesture(in geo: GeometryProxy, controlsMinY: CGFloat) -> some Gesture {
-        DragGesture()
-            .onChanged { value in
-                if !draggingDPad { draggingDPad = true }
-                let newCenter = value.location
-                let clamped = clampToSafeArea(newCenter, controlSize: layout.dpadSize, in: geo, controlsMinY: controlsMinY)
-                layout.dpadRelativeCenter = CGPoint(
-                    x: clamped.x / geo.size.width,
-                    y: clamped.y / geo.size.height
-                )
-            }
-            .onEnded { _ in
-                draggingDPad = false
-                layout.save()
-            }
-    }
-
-
-    @ViewBuilder
-    private func actionButtonView(button: ButtonModel, index: Int, in geo: GeometryProxy, controlsMinY: CGFloat) -> some View {
-        let pos = absolutePosition(for: button.relativeCenter, in: geo.size, controlSize: CGSize(width: button.size, height: button.size), safeArea: AppWindow.currentSafeArea, controlsMinY: controlsMinY)
-        let isDragging = draggingButtonID == button.id
-        let anchor = UnitPoint(x: pos.x / geo.size.width, y: pos.y / geo.size.height)
-        ActionButton(
-            label: button.label,
-            scancode: button.scancode,
-            size: button.size,
-            editing: editMode
-        )
-        .frame(width: button.size, height: button.size)
-        .opacity(button.opacity)
-        .onTapGesture {
-            guard editMode else { return }
-            editingButton = button
-        }
-        .overlay(alignment: .topTrailing) {
-            if editMode && !isDragging {
-                Button {
-                    withAnimation(Motion.snappy) {
-                        layout.removeButton(id: button.id)
-                    }
-                } label: {
-                    Chip(systemImage: "xmark", tint: .destructive)
-                }
-                .transition(.scale.combined(with: .opacity))
-            }
-        }
-        .scaleEffect(isDragging ? kDragScaleFactor : 1.0)
-        .animation(Motion.snappy, value: isDragging)
-        .position(pos)
-        .transition(.controlAppear(anchor: anchor))
-        .gesture(buttonDragGesture(id: button.id, size: button.size, in: geo, controlsMinY: controlsMinY), including: editMode ? .all : .none)
-    }
-
-    private func buttonDragGesture(id: UUID, size: CGFloat, in geo: GeometryProxy, controlsMinY: CGFloat) -> some Gesture {
-        DragGesture()
-            .onChanged { value in
-                if draggingButtonID != id { draggingButtonID = id }
-                let newCenter = value.location
-                let clamped = clampToSafeArea(newCenter, controlSize: size, in: geo, controlsMinY: controlsMinY)
-                layout.updateButton(id: id, relativeCenter: CGPoint(
-                    x: clamped.x / geo.size.width,
-                    y: clamped.y / geo.size.height
-                ))
-            }
-            .onEnded { _ in
-                draggingButtonID = nil
-                layout.save()
-            }
-    }
-
-
-    @ViewBuilder
-    private func toolbarButtons(isPortrait: Bool, gameRect: CGRect, safeArea: EdgeInsets, geoSize: CGSize) -> some View {
-        let btnSize = IconButtonSize.sm.points
-        let gap: CGFloat = isPortrait ? Spacing.sm : Spacing.md
-
-        let buttons: [(icon: String, label: String, action: () -> Void, tint: Color?)] = {
-            var list: [(icon: String, label: String, action: () -> Void, tint: Color?)] = []
-            if settings.isEnabled(.gamePause) {
-                list.append(("pause.fill", "Pause game", { appState.requestPause() }, .white))
-            }
-            list.append(("keyboard", "Toggle keyboard", { toggleKeyboard() }, .white))
-            if settings.debugMode {
-                list.append(("chart.line.uptrend.xyaxis", "Debug overlay", { showDebugOverlay.toggle() }, .white))
-            }
-            list.append(("gearshape.fill", "Edit controls", { toggleEditMode() }, .white))
-            list.append((controlsHidden ? "eye.slash.fill" : "eye.fill", controlsHidden ? "Show controls" : "Hide controls", { toggleHideControls() }, .white))
-            if settings.isEnabled(.gameQuit) {
-                list.append(("xmark.circle.fill", "Quit game", { showQuitConfirm = true }, .destructive))
-            }
-            return list
-        }()
-
-        let toolbarPosition = toolbarOrigin(isPortrait: isPortrait, gameRect: gameRect, safeArea: safeArea, geoSize: geoSize, btnSize: btnSize, gap: gap, count: CGFloat(buttons.count))
-
-        HStack(spacing: gap) {
-            ForEach(Array(buttons.enumerated()), id: \.offset) { _, entry in
-                IconButton(
-                    entry.icon,
-                    style: .outline,
-                    size: IconButtonSize.sm,
-                    tint: entry.tint
-                ) {
-                    resetToolbarIdleTimer()
-                    entry.action()
-                }
-                .accessibilityLabel(entry.label)
-            }
-        }
-        // Pin the Liquid Glass material to the dark variant so the
-        // toolbar matches the on-screen controls (D-pad, action
-        // buttons) and doesn't shift appearance with the system
-        // color scheme or the backdrop brightness of the game.
-        .darkGlass()
-        .opacity(toolbarOpacity)
-        .position(toolbarPosition)
-    }
-
-
-    @ViewBuilder
-    private func editToolbar(isPortrait: Bool, gameRect: CGRect, safeArea: EdgeInsets, geoSize: CGSize) -> some View {
-        let overlay = useOverlayLayout(isPortrait: isPortrait, gameRect: gameRect, safeArea: safeArea, geoHeight: geoSize.height)
-        let yPos: CGFloat = isPortrait && gameRect.height > 0 && !overlay
-            ? gameRect.origin.y + gameRect.height + kToolbarGap + kEditToolbarHalfHeight
-            : max(safeArea.top, kMinLandscapeInset) + kToolbarEdgePad + kEditToolbarHalfHeight
-
-        HStack(spacing: Spacing.xl) {
-            Button("+ Add") { showAddSheet = true }
-                .accessibilityLabel("Add button")
-                .foregroundStyle(.white)
-                .font(.footnote.weight(.semibold))
-            Button("Reset") { showResetConfirm = true }
-                .foregroundStyle(.brand)
-                .font(.footnote.weight(.semibold))
-            Button("Done") { toggleEditMode() }
-                .foregroundStyle(.success)
-                .font(.footnote.weight(.bold))
-        }
-        .padding(.horizontal, Spacing.xl)
-        .padding(.vertical, Spacing.sm)
-        .background(Color.black.opacity(Overlay.heavy))
-        .clipShape(RoundedRectangle(cornerRadius: Radius.md))
-        .position(x: geoSize.width / 2, y: yPos)
-    }
-
-
-    @ViewBuilder
     private func editZoneBackground(controlsMinY: CGFloat, safeArea: EdgeInsets, geoSize: CGSize) -> some View {
-        let bounds = zoneBounds(controlsMinY: controlsMinY, safeArea: safeArea, geoSize: geoSize)
-        let radii = zoneCornerRadii(safeArea: safeArea)
+        let bounds = ControlsZone.bounds(controlsMinY: controlsMinY, safeArea: safeArea, geoSize: geoSize)
+        let radii = ControlsZone.cornerRadii(safeArea: safeArea)
 
         UnevenRoundedRectangle(
             topLeadingRadius: radii.top,
@@ -371,125 +220,6 @@ struct PlayerView: View {
         .position(x: bounds.midX, y: bounds.midY)
         .allowsHitTesting(false)
         .transition(.opacity)
-    }
-
-    private func zoneBounds(controlsMinY: CGFloat, safeArea: EdgeInsets, geoSize: CGSize) -> CGRect {
-        let pad = kControlsZonePadding
-        let top = controlsMinY + pad
-        let bottom = geoSize.height - safeArea.bottom - pad
-        let leading = safeArea.leading + pad
-        let trailing = geoSize.width - safeArea.trailing - pad
-        return CGRect(x: leading, y: top, width: trailing - leading, height: bottom - top)
-    }
-
-    private func zoneCornerRadii(safeArea: EdgeInsets) -> (top: CGFloat, bottom: CGFloat) {
-        let pad = kControlsZonePadding
-        let screen = UIApplication.shared.connectedScenes
-            .compactMap { $0 as? UIWindowScene }
-            .first?.screen
-        let deviceCorner = (screen?.value(forKey: "displayCornerRadius") as? CGFloat) ?? kFallbackDeviceCornerRadius
-        let horizontalGap = safeArea.leading + pad
-        let bottomGap = safeArea.bottom + pad
-        let minGap = min(horizontalGap, bottomGap)
-        let bottom = max(deviceCorner - minGap, Radius.sm)
-        let top = Radius.xl
-        return (top, bottom)
-    }
-
-
-    private func toolbarOrigin(isPortrait: Bool, gameRect: CGRect, safeArea: EdgeInsets, geoSize: CGSize, btnSize: CGFloat, gap: CGFloat, count: CGFloat) -> CGPoint {
-        // Always anchor the toolbar to the top-right of the device
-        // viewport. In portrait we used to tuck it below the game rect,
-        // which left the keyboard-toggle button covered by the keyboard
-        // whenever it was up. Placing it at the top keeps it reachable
-        // in every orientation + layout mode.
-        let totalW = count * btnSize + (count - 1) * gap
-        let rightInset = max(safeArea.trailing, kMinLandscapeInset)
-        let topInset = max(safeArea.top, kMinLandscapeInset)
-        let x = geoSize.width - rightInset - kToolbarEdgePad - totalW / 2
-        let y = topInset + kToolbarEdgePad + btnSize / 2
-        return CGPoint(x: x, y: y)
-    }
-
-    /// Minimum vertical space below the game rect required to place the
-    /// toolbar + controls in the dedicated zone below the game. When the
-    /// game fills most of the screen (e.g. fixedAspectRatio off) there
-    /// isn't enough room, so we fall back to overlay mode (same as
-    /// landscape: toolbar at top, controls over the game).
-    private static let kMinControlsZoneHeight: CGFloat = 120
-
-    private func useOverlayLayout(isPortrait: Bool, gameRect: CGRect, safeArea: EdgeInsets, geoHeight: CGFloat) -> Bool {
-        guard isPortrait, gameRect.height > 0 else { return false }
-        let spaceBelow = geoHeight - (gameRect.origin.y + gameRect.height) - safeArea.bottom
-        return spaceBelow < Self.kMinControlsZoneHeight
-    }
-
-    /// Top edge of the controls zone - controls can only live below
-    /// this Y. In portrait with space below the game, the zone begins
-    /// right at the game's bottom edge (toolbar is now at the top so
-    /// it doesn't push controls down). In overlay / landscape, the
-    /// zone begins below the toolbar that sits in the top-right.
-    private func toolbarBottomY(isPortrait: Bool, gameRect: CGRect, safeArea: EdgeInsets, btnSize: CGFloat, geoHeight: CGFloat) -> CGFloat {
-        if isPortrait && gameRect.height > 0 && !useOverlayLayout(isPortrait: isPortrait, gameRect: gameRect, safeArea: safeArea, geoHeight: geoHeight) {
-            return gameRect.origin.y + gameRect.height + kToolbarGap
-        } else {
-            let topInset = max(safeArea.top, kMinLandscapeInset)
-            return topInset + kToolbarEdgePad + btnSize + kToolbarEdgePad
-        }
-    }
-
-    private func absolutePosition(for relativeCenter: CGPoint, in size: CGSize, controlSize: CGSize, safeArea: EdgeInsets, controlsMinY: CGFloat) -> CGPoint {
-        let pad = kControlsZonePadding + kControlsZoneInnerPadding
-        let hw = controlSize.width * 0.5
-        let hh = controlSize.height * 0.5
-        let minX = safeArea.leading + pad + hw
-        let minY = max(safeArea.top + pad + hh, controlsMinY + pad + hh)
-        let maxX = size.width - safeArea.trailing - pad - hw
-        let maxY = size.height - safeArea.bottom - pad - hh
-        let cx = max(minX, min(relativeCenter.x * size.width, maxX))
-        let cy = max(minY, min(relativeCenter.y * size.height, maxY))
-        let zone = zoneBounds(controlsMinY: controlsMinY, safeArea: safeArea, geoSize: size)
-        let radii = zoneCornerRadii(safeArea: safeArea)
-        return clampToRoundedCorners(CGPoint(x: cx, y: cy), controlHalf: max(hw, hh), zone: zone, radii: radii)
-    }
-
-    private func clampToSafeArea(_ point: CGPoint, controlSize: CGFloat, in geo: GeometryProxy, controlsMinY: CGFloat) -> CGPoint {
-        let safe = AppWindow.currentSafeArea
-        let pad = kControlsZonePadding + kControlsZoneInnerPadding
-        let hw = controlSize * 0.5
-        let x = max(safe.leading + pad + hw, min(point.x, geo.size.width - safe.trailing - pad - hw))
-        let minY = max(safe.top + pad + hw, controlsMinY + pad + hw)
-        let y = max(minY, min(point.y, geo.size.height - safe.bottom - pad - hw))
-        let zone = zoneBounds(controlsMinY: controlsMinY, safeArea: safe, geoSize: geo.size)
-        let radii = zoneCornerRadii(safeArea: safe)
-        return clampToRoundedCorners(CGPoint(x: x, y: y), controlHalf: hw, zone: zone, radii: radii)
-    }
-
-    private func clampToRoundedCorners(_ point: CGPoint, controlHalf: CGFloat, zone: CGRect, radii: (top: CGFloat, bottom: CGFloat)) -> CGPoint {
-        var p = point
-        let corners: [(cx: CGFloat, cy: CGFloat, r: CGFloat)] = [
-            (zone.minX + radii.top, zone.minY + radii.top, radii.top),
-            (zone.maxX - radii.top, zone.minY + radii.top, radii.top),
-            (zone.minX + radii.bottom, zone.maxY - radii.bottom, radii.bottom),
-            (zone.maxX - radii.bottom, zone.maxY - radii.bottom, radii.bottom),
-        ]
-        for corner in corners {
-            let inCornerX = (p.x < corner.cx && corner.cx <= zone.minX + max(radii.top, radii.bottom))
-                         || (p.x > corner.cx && corner.cx >= zone.maxX - max(radii.top, radii.bottom))
-            let inCornerY = (p.y < corner.cy && corner.cy <= zone.minY + max(radii.top, radii.bottom))
-                         || (p.y > corner.cy && corner.cy >= zone.maxY - max(radii.top, radii.bottom))
-            guard inCornerX && inCornerY else { continue }
-            let dx = p.x - corner.cx
-            let dy = p.y - corner.cy
-            let dist = sqrt(dx * dx + dy * dy)
-            let maxDist = corner.r - controlHalf - kControlsZoneInnerPadding
-            if maxDist > 0 && dist > maxDist {
-                let scale = maxDist / dist
-                p.x = corner.cx + dx * scale
-                p.y = corner.cy + dy * scale
-            }
-        }
-        return p
     }
 
 


### PR DESCRIPTION
## Summary
- Extract `ControlsZone` enum (ControlsZoneGeometry.swift) with pure static geometry helpers: bounds, cornerRadii, useOverlayLayout, toolbarBottomY, toolbarOrigin, absolutePosition, clampToSafeArea, clampToRoundedCorners.
- Extract `PlayerToolbar` + `PlayerEditToolbar` views (PlayerToolbar.swift) for the top-right toolbar and edit-mode toolbar.
- Extract `PlayerControlsOverlay` view (PlayerControlsOverlay.swift) for the d-pad + action buttons and their drag gestures.
- PlayerView.swift reduced from 560 to 290 lines; now focuses on state, lifecycle, alerts, and composition.

## Test plan
- Sim + device builds green.
- Verified on iPhone 13 Pro: d-pad and button drag, delete chip, edit mode toggle, toolbar auto-dim, keyboard toggle, pause, quit confirm, hide controls, debug overlay, portrait/landscape rotation.