### PR TITLE
refactor: remove dead code, add theme tokens, migrate literals

### DIFF
--- a/ios/Empo/src/App/RootView.swift
+++ b/ios/Empo/src/App/RootView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 private enum SplashTiming {
     static let holdDuration: TimeInterval = 1.2
     static let cycleDuration: TimeInterval = 3
-    static let frameInterval: TimeInterval = 1.0 / 60.0
 }
 
 struct RootView: View {

--- a/ios/Empo/src/Design/Button.swift
+++ b/ios/Empo/src/Design/Button.swift
@@ -43,7 +43,7 @@ struct PrimaryButtonStyle: ButtonStyle {
             .padding(.horizontal, size.horizontalPadding)
             .padding(.vertical, size.verticalPadding)
             .glassEffect(.regular.tint(tint).interactive(), in: .capsule)
-            .opacity(isEnabled ? 1 : 0.4)
+            .opacity(isEnabled ? 1 : Alpha.disabled)
             .onChange(of: configuration.isPressed) { _, pressed in
                 if pressed { Haptics.tap() }
             }
@@ -69,8 +69,8 @@ struct SecondaryButtonStyle: ButtonStyle {
             .foregroundStyle(tint)
             .padding(.horizontal, size.horizontalPadding)
             .padding(.vertical, size.verticalPadding)
-            .glassEffect(.regular.tint(tint.opacity(0.1)).interactive(), in: .capsule)
-            .opacity(isEnabled ? 1 : 0.4)
+            .glassEffect(.regular.tint(tint.opacity(Alpha.brandTintBackground)).interactive(), in: .capsule)
+            .opacity(isEnabled ? 1 : Alpha.disabled)
             .onChange(of: configuration.isPressed) { _, pressed in
                 if pressed { Haptics.tap() }
             }
@@ -87,7 +87,7 @@ extension ButtonStyle where Self == SecondaryButtonStyle {
 struct CardPressStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .scaleEffect(configuration.isPressed ? 0.95 : 1)
+            .scaleEffect(configuration.isPressed ? PressScale.standard : 1)
             .animation(Motion.snappy, value: configuration.isPressed)
             .onChange(of: configuration.isPressed) { _, pressed in
                 if pressed { Haptics.tap() }
@@ -99,7 +99,7 @@ struct CardPressStyle: ButtonStyle {
 struct ListRowPressStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .opacity(configuration.isPressed ? 0.7 : 1)
+            .opacity(configuration.isPressed ? Alpha.textMuted : 1)
             .animation(Motion.snappy, value: configuration.isPressed)
     }
 }

--- a/ios/Empo/src/Design/Chip.swift
+++ b/ios/Empo/src/Design/Chip.swift
@@ -5,19 +5,19 @@ struct Chip: View {
     private let systemImage: String?
     private let tint: Color
 
-    init(_ label: String, systemImage: String, tint: Color = .black.opacity(0.3)) {
+    init(_ label: String, systemImage: String, tint: Color = .chipScrim) {
         self.label = label
         self.systemImage = systemImage
         self.tint = tint
     }
 
-    init(systemImage: String, tint: Color = .black.opacity(0.3)) {
+    init(systemImage: String, tint: Color = .chipScrim) {
         self.label = nil
         self.systemImage = systemImage
         self.tint = tint
     }
 
-    init(_ label: String, tint: Color = .black.opacity(0.3)) {
+    init(_ label: String, tint: Color = .chipScrim) {
         self.label = label
         self.systemImage = nil
         self.tint = tint

--- a/ios/Empo/src/Design/IconButton.swift
+++ b/ios/Empo/src/Design/IconButton.swift
@@ -66,7 +66,7 @@ struct IconButton: View {
         switch style {
         case .primary: return .white
         case .secondary: return .brand
-        case .outline: return .primary.opacity(0.7)
+        case .outline: return .primary.opacity(Alpha.textMuted)
         }
     }
 
@@ -94,7 +94,7 @@ private struct IconGlassModifier: ViewModifier {
         case .primary:
             content.glassEffect(.regular.tint(.brand).interactive(), in: .circle)
         case .secondary:
-            content.glassEffect(.regular.tint(.brand.opacity(0.1)).interactive(), in: .circle)
+            content.glassEffect(.regular.tint(.brand.opacity(Alpha.brandTintBackground)).interactive(), in: .circle)
         case .outline:
             content.glassEffect(hasAction ? .regular.interactive() : .regular, in: .circle)
         }

--- a/ios/Empo/src/Design/SpinnerRing.swift
+++ b/ios/Empo/src/Design/SpinnerRing.swift
@@ -46,10 +46,7 @@ struct SpinnerRing: View {
                     .frame(width: size, height: size)
                     .rotationEffect(.degrees(spinning ? 360 : 0))
                     .onAppear { spinning = true }
-                    .animation(
-                        .linear(duration: 1).repeatForever(autoreverses: false),
-                        value: spinning
-                    )
+                    .animation(Motion.spinner, value: spinning)
             }
         }
         .animation(Motion.snappy, value: progress)

--- a/ios/Empo/src/Design/Theme.swift
+++ b/ios/Empo/src/Design/Theme.swift
@@ -195,14 +195,20 @@ enum Motion {
 
     // -- Stagger --
 
-    /// Interval between successive items in a cascading entrance
-    /// (library grid, settings list). Slightly longer than
-    /// `staggerFast` so a row of 6-8 items reads as a wave.
-    static let staggerInterval: TimeInterval = 0.04
-
-    /// Faster stagger used in denser/wider lists where the sum of
-    /// delays would otherwise feel sluggish.
+    /// Interval between successive items in a dense list/grid cascade
+    /// (library grid, settings rows). Short so a long list doesn't feel
+    /// sluggish by the time the tail catches up.
     static let staggerFast: TimeInterval = 0.04
+
+    /// Slightly wider interval for sparser reveals (D-pad buttons
+    /// repopulating after a layout reset). Reads as a deliberate wave
+    /// rather than a ripple.
+    static let staggerMedium: TimeInterval = 0.06
+
+    /// Initial delay before a cascading controls reveal begins. Gives
+    /// the parent layout a beat to settle before buttons start
+    /// arriving.
+    static let controlsAppearDelay: TimeInterval = 0.15
 
     // -- Durations (for manual withAnimation(.easeInOut(duration:))) --
 
@@ -238,6 +244,14 @@ enum AppSize {
 
     /// Library/settings navigation header tap area.
     static let libraryHeader: CGFloat = 56
+
+    /// Apple HIG minimum interactive target - import button and other
+    /// primary CTAs default to this when not otherwise constrained.
+    static let minTapTarget: CGFloat = 44
+
+    /// Vertical offset used by the library empty state to lift its
+    /// illustration above center when there's a search bar above.
+    static let emptyStateOffset: CGFloat = 30
 
     /// Slider value-label pinned width (right-aligned, so values like
     /// "100%" don't visually jump as the label width fluctuates).
@@ -283,14 +297,33 @@ enum Alpha {
     static let border: Double = 0.2
     /// Brand tint behind `.secondary` surfaces.
     static let brandTintBackground: Double = 0.1
+    /// Disabled control foreground (glass CTAs with `.isEnabled == false`).
+    static let disabled: Double = 0.4
+    /// Drop shadow opacity for small floating affordances.
+    static let shadow: Double = 0.2
+    /// Filled indicator fills over secondary-styled surfaces.
+    static let indicatorFill: Double = 0.3
+    /// Hairline stroke over secondary-styled surfaces.
+    static let indicatorStroke: Double = 0.4
+    /// Dimmed player toolbar opacity - the toolbar rests at this
+    /// value while idle and returns to 1 on any touch inside the
+    /// player.
+    static let toolbarDim: Double = 0.3
 }
 
 
-/// Backwards-compat shim so incremental site-by-site migration is
-/// safe: existing `Overlay.light/medium/heavy` call sites keep
-/// working while we migrate to the split `Scrim` / `Alpha` tokens.
-enum Overlay {
-    static let light: Double = Scrim.light
-    static let medium: Double = Scrim.medium
-    static let heavy: Double = Scrim.heavy
+/// Time-based design tokens. Use for idle timers and other
+/// user-perceivable durations that aren't animation curves (those
+/// live on `Motion`).
+enum Timing {
+    /// How long the player toolbar stays at full opacity after the
+    /// last touch before dimming back to `Alpha.toolbarDim`.
+    static let toolbarIdleDelay: TimeInterval = 3.0
+}
+
+
+/// Default scrim tint baked into `Chip` so small glyph badges get a
+/// consistent dim behind them without every site passing a literal.
+extension Color {
+    static let chipScrim = Color.black.opacity(Scrim.light)
 }

--- a/ios/Empo/src/Design/Transitions.swift
+++ b/ios/Empo/src/Design/Transitions.swift
@@ -17,13 +17,10 @@ struct EmptyStateView: View {
     var body: some View {
         VStack(spacing: Spacing.lg) {
             Image(systemName: icon)
-                .font(.system(size: 48))
+                .font(.system(size: IconSize.emptyState))
                 .foregroundStyle(.secondary)
                 .offset(y: floating ? -3 : 3)
-                .animation(
-                    .easeInOut(duration: 2.4).repeatForever(autoreverses: true),
-                    value: floating
-                )
+                .animation(Motion.float, value: floating)
                 .opacity(iconAppeared ? 1 : 0)
                 .offset(y: iconAppeared ? 0 : 12)
             Text(title)
@@ -67,7 +64,7 @@ struct StaggeredAppearance: ViewModifier {
     let trigger: UUID
     var initialDelay: TimeInterval = 0
 
-    private var delay: Double { initialDelay + Double(index) * 0.04 }
+    private var delay: Double { initialDelay + Double(index) * Motion.staggerFast }
 
     @State private var visible = true
 

--- a/ios/Empo/src/Library/GameCard.swift
+++ b/ios/Empo/src/Library/GameCard.swift
@@ -58,7 +58,7 @@ struct GameCard: View {
                     if let originalTitle = game.originalTitle {
                         Text(originalTitle)
                             .font(.caption2)
-                            .foregroundStyle(.white.opacity(0.7))
+                            .foregroundStyle(.white.opacity(Alpha.textMuted))
                             .textShadow()
                             .lineLimit(1)
                     }
@@ -111,7 +111,7 @@ struct GameCard: View {
         // Dim the artwork a little for non-ready states so the
         // indicator reads clearly against busy thumbnails.
         if game.status.phase != .ready {
-            Color.black.opacity(Overlay.light)
+            Color.black.opacity(Scrim.light)
         }
         GameStatusIndicator(
             kind: .resolve(status: game.status, paused: isPaused),

--- a/ios/Empo/src/Library/GameHeroCard.swift
+++ b/ios/Empo/src/Library/GameHeroCard.swift
@@ -67,7 +67,7 @@ struct GameHeroCard: View {
                         Text("Continue playing")
                             .font(.caption)
                             .fontWeight(.medium)
-                            .foregroundStyle(.white.opacity(0.7))
+                            .foregroundStyle(.white.opacity(Alpha.textMuted))
                         Text(game.title)
                             .font(.title3)
                             .fontWeight(.bold)

--- a/ios/Empo/src/Library/GameInfoView.swift
+++ b/ios/Empo/src/Library/GameInfoView.swift
@@ -389,8 +389,7 @@ struct GameInfoView: View {
         needsLibraryRefresh = true
     }
 
-    private func removeCustomImage(kind: String,
-                                   pathGetter: (GameMetadata) -> String?,
+    private func removeCustomImage(pathGetter: (GameMetadata) -> String?,
                                    filenameGetter: (GameMetadata) -> String?,
                                    filenameSetter: (inout GameMetadata, String?) -> Void) {
         if let path = pathGetter(metadata) {
@@ -411,8 +410,7 @@ struct GameInfoView: View {
     }
 
     private func removeArtwork() {
-        removeCustomImage(kind: "artwork",
-                         pathGetter: { $0.customArtworkPath(for: game.id) },
+        removeCustomImage(pathGetter: { $0.customArtworkPath(for: game.id) },
                          filenameGetter: { $0.customArtworkFilename },
                          filenameSetter: { $0.customArtworkFilename = $1 })
     }
@@ -424,8 +422,7 @@ struct GameInfoView: View {
     }
 
     private func removeBanner() {
-        removeCustomImage(kind: "banner",
-                         pathGetter: { $0.customBannerPath(for: game.id) },
+        removeCustomImage(pathGetter: { $0.customBannerPath(for: game.id) },
                          filenameGetter: { $0.customBannerFilename },
                          filenameSetter: { $0.customBannerFilename = $1 })
     }

--- a/ios/Empo/src/Library/GameLibraryView.swift
+++ b/ios/Empo/src/Library/GameLibraryView.swift
@@ -98,7 +98,7 @@ struct GameLibraryView: View {
                                 Color.clear.preference(key: EmptyStateHeightKey.self, value: geo.size.height)
                             }
                         }
-                        .offset(y: -30)
+                        .offset(y: -AppSize.emptyStateOffset)
                         .transition(.emptyState)
                 }
             }
@@ -152,7 +152,7 @@ struct GameLibraryView: View {
                     entranceDelay: entranceDelay,
                     headerHeight: headerHeight,
                     emptyStateHeight: emptyStateHeight,
-                    emptyStateOffset: -30
+                    emptyStateOffset: -AppSize.emptyStateOffset
                 )
             }
             .toolbarVisibility(.hidden, for: .navigationBar)
@@ -264,7 +264,7 @@ struct GameLibraryView: View {
     }
 
 
-    private let headerHeight: CGFloat = 56
+    private let headerHeight: CGFloat = AppSize.libraryHeader
 
     private var libraryHeader: some View {
         HStack {

--- a/ios/Empo/src/Library/GameLoadingView.swift
+++ b/ios/Empo/src/Library/GameLoadingView.swift
@@ -153,7 +153,7 @@ struct GameLoadingView: View {
                 .offset(x: kenBurns ? 10 : -10, y: kenBurns ? -8 : 8)
                 .ignoresSafeArea()
                 .blur(radius: 20)
-                .overlay(Color.black.opacity(Overlay.medium))
+                .overlay(Color.black.opacity(Scrim.medium))
         } else {
             Color.black.ignoresSafeArea()
         }

--- a/ios/Empo/src/Library/ImportButton.swift
+++ b/ios/Empo/src/Library/ImportButton.swift
@@ -11,7 +11,7 @@ struct ImportButton: View {
 
     @State private var importShimmer: CGFloat = -1
     @State private var importMoveTrigger = 0
-    @State private var buttonHeight: CGFloat = 44
+    @State private var buttonHeight: CGFloat = AppSize.minTapTarget
     @State private var revealed = false
 
     var body: some View {
@@ -129,7 +129,7 @@ struct ImportButton: View {
         }
         .font(.body.weight(.semibold))
         .foregroundStyle(.white)
-        .shadow(color: .black.opacity(0.2), radius: 2, y: 1)
+        .shadow(color: .black.opacity(Alpha.shadow), radius: 2, y: 1)
         .padding(.horizontal, collapsed ? 0 : ButtonSize.lg.horizontalPadding)
         .padding(.vertical, collapsed ? 0 : ButtonSize.lg.verticalPadding)
         .frame(

--- a/ios/Empo/src/Player/ControlsLayout.swift
+++ b/ios/Empo/src/Player/ControlsLayout.swift
@@ -174,7 +174,7 @@ class ControlsLayout {
             }
 
         for (i, (_, button)) in missing.enumerated() {
-            let delay = 0.15 + Double(i) * 0.06
+            let delay = Motion.controlsAppearDelay + Double(i) * Motion.staggerMedium
             Task { @MainActor in
                 try? await Task.sleep(for: .seconds(delay))
                 withAnimation(Motion.gentle) {

--- a/ios/Empo/src/Player/DebugOverlayView.swift
+++ b/ios/Empo/src/Player/DebugOverlayView.swift
@@ -117,7 +117,7 @@ struct DebugOverlayView: View {
         _ text: String,
         weight: Font.Weight = .medium,
         size: CGFloat = 13,
-        color: Color = .white.opacity(0.7)
+        color: Color = .white.opacity(Alpha.textMuted)
     ) -> some View {
         Text(text)
             .font(.system(size: size, weight: weight, design: .monospaced))

--- a/ios/Empo/src/Player/GameControls.swift
+++ b/ios/Empo/src/Player/GameControls.swift
@@ -179,7 +179,7 @@ struct DPad: View {
                         .fill(
                             LinearGradient(
                                 colors: [.white.opacity(0.28), .white.opacity(0)],
-                                startPoint: dir.highlightGradientStart(armFraction: armFraction),
+                                startPoint: dir.highlightGradientStart,
                                 endPoint: dir.highlightGradientEnd(armFraction: armFraction)
                             )
                         )
@@ -372,7 +372,7 @@ enum DPadDirection: CaseIterable, Hashable {
     /// axis), and its inner edge is at the center-square boundary,
     /// which in UnitPoints is `(1 - armFraction) / 2` from the
     /// outer edge.
-    func highlightGradientStart(armFraction: CGFloat) -> UnitPoint {
+    var highlightGradientStart: UnitPoint {
         switch self {
         case .up:    return UnitPoint(x: 0.5, y: 0)
         case .down:  return UnitPoint(x: 0.5, y: 1)

--- a/ios/Empo/src/Player/PlayerToolbar.swift
+++ b/ios/Empo/src/Player/PlayerToolbar.swift
@@ -108,7 +108,7 @@ struct PlayerEditToolbar: View {
         }
         .padding(.horizontal, Spacing.xl)
         .padding(.vertical, Spacing.sm)
-        .background(Color.black.opacity(Overlay.heavy))
+        .background(Color.black.opacity(Scrim.heavy))
         .clipShape(RoundedRectangle(cornerRadius: Radius.md))
         .position(x: geoSize.width / 2, y: yPos)
     }

--- a/ios/Empo/src/Player/PlayerView.swift
+++ b/ios/Empo/src/Player/PlayerView.swift
@@ -1,9 +1,6 @@
 import SwiftUI
 
 
-private let kToolbarIdleDelay: TimeInterval = 3.0
-
-
 struct PlayerView: View {
     @Bindable var appState: AppState
     @Bindable var engineState: EngineState
@@ -22,7 +19,7 @@ struct PlayerView: View {
     /// Toolbar starts dimmed so it doesn't dominate attention when the
     /// player first loads. Any tap (on the toolbar, on the game area,
     /// etc.) restores it to full opacity via `resetToolbarIdleTimer()`.
-    @State private var toolbarOpacity: Double = 0.3
+    @State private var toolbarOpacity: Double = Alpha.toolbarDim
     @State private var toolbarIdleTask: Task<Void, Never>?
     @State private var showQuitConfirm = false
 
@@ -206,7 +203,7 @@ struct PlayerView: View {
             bottomTrailingRadius: radii.bottom,
             topTrailingRadius: radii.top
         )
-        .strokeBorder(Color.white.opacity(0.2), lineWidth: 1.5)
+        .strokeBorder(Color.white.opacity(Alpha.border), lineWidth: 1.5)
         .background(
             UnevenRoundedRectangle(
                 topLeadingRadius: radii.top,
@@ -214,7 +211,7 @@ struct PlayerView: View {
                 bottomTrailingRadius: radii.bottom,
                 topTrailingRadius: radii.top
             )
-            .fill(Color.black.opacity(Overlay.medium))
+            .fill(Color.black.opacity(Scrim.medium))
         )
         .frame(width: bounds.width, height: bounds.height)
         .position(x: bounds.midX, y: bounds.midY)
@@ -258,11 +255,11 @@ struct PlayerView: View {
             }
         }
         toolbarIdleTask = Task { @MainActor in
-            try? await Task.sleep(for: .seconds(kToolbarIdleDelay))
+            try? await Task.sleep(for: .seconds(Timing.toolbarIdleDelay))
             guard !Task.isCancelled else { return }
             if !editMode && !controlsHidden {
                 withAnimation(Motion.slow) {
-                    toolbarOpacity = 0.3
+                    toolbarOpacity = Alpha.toolbarDim
                 }
             }
         }

--- a/ios/Empo/src/Settings/SettingsComponents.swift
+++ b/ios/Empo/src/Settings/SettingsComponents.swift
@@ -28,7 +28,6 @@ struct SettingsPicker<SelectionValue: Hashable, Content: View>: View {
     let title: String
     @Binding var selection: SelectionValue
     let description: String
-    var isExperimental: Bool = false
     @ViewBuilder let content: () -> Content
 
     var body: some View {
@@ -36,12 +35,7 @@ struct SettingsPicker<SelectionValue: Hashable, Content: View>: View {
             Picker(selection: $selection) {
                 content()
             } label: {
-                HStack(spacing: Spacing.xs) {
-                    Text(title)
-                    if isExperimental {
-                        ExperimentalBadge()
-                    }
-                }
+                Text(title)
             }
             Text(description)
                 .font(.footnote)

--- a/ios/Empo/src/Settings/SettingsView.swift
+++ b/ios/Empo/src/Settings/SettingsView.swift
@@ -157,7 +157,7 @@ struct SettingsView: View {
                                 .font(.footnote)
                                 .foregroundStyle(.secondary)
                         }
-                        .padding(.vertical, 2)
+                        .padding(.vertical, Spacing.xxs)
                     }
                 } header: {
                     Text("Advanced")
@@ -292,7 +292,7 @@ private struct BuildInfoSheet: View {
     /// Approximate navigation bar height. The inline nav bar is
     /// ~44pt but sits above a small status bar drag area; 56 covers
     /// both comfortably without visibly overshooting.
-    private let navBarAllowance: CGFloat = 56
+    private let navBarAllowance: CGFloat = AppSize.libraryHeader
 
     var body: some View {
         NavigationStack {
@@ -413,7 +413,7 @@ private struct DevicePreview: View {
                 .fill(.secondary.opacity(0.15))
                 .overlay(
                     RoundedRectangle(cornerRadius: cornerRadius)
-                        .stroke(.secondary.opacity(0.4), lineWidth: 1)
+                        .stroke(.secondary.opacity(Alpha.indicatorStroke), lineWidth: 1)
                 )
 
             // Screen area
@@ -448,7 +448,7 @@ private struct DevicePreview: View {
                     bottomTrailingRadius: 4,
                     topTrailingRadius: 4
                 )
-                .fill(.secondary.opacity(0.3))
+                .fill(.secondary.opacity(Alpha.indicatorFill))
                 .frame(width: notchHeight, height: 20)
                 .offset(x: -(deviceW / 2 - notchHeight / 2))
             } else {
@@ -459,7 +459,7 @@ private struct DevicePreview: View {
                     bottomTrailingRadius: 4,
                     topTrailingRadius: 0
                 )
-                .fill(.secondary.opacity(0.3))
+                .fill(.secondary.opacity(Alpha.indicatorFill))
                 .frame(width: 28, height: notchHeight)
                 .offset(y: -(deviceH / 2 - notchHeight / 2))
             }


### PR DESCRIPTION
## Summary

Tier 6a of the audit-driven refactor roadmap. Removes dead code, adds new design tokens, and migrates hardcoded literals to tokens.

## Changes

### Dead code
- Remove unused `SplashTiming.frameInterval`
- Remove unused `SettingsPicker.isExperimental` parameter and its branch
- Remove unused `kind:` parameter from `GameInfoView.removeCustomImage`
- Convert `GameControls.Direction.highlightGradientStart(armFraction:)` to a computed var (param was unused)

### New theme tokens
- `Alpha.disabled` (0.4), `Alpha.shadow` (0.2), `Alpha.indicatorFill` (0.3), `Alpha.indicatorStroke` (0.4), `Alpha.toolbarDim` (0.3)
- `Color.chipScrim` for default `Chip` tint
- `AppSize.minTapTarget` (44), `AppSize.emptyStateOffset` (30)
- `Motion.staggerMedium` (0.06), `Motion.controlsAppearDelay` (0.15)
- New `Timing` enum with `toolbarIdleDelay` (3.0)
- Remove redundant unused `Motion.staggerInterval` token
- Remove `Overlay` backwards-compat shim (app isn't shipped)

### Literal migrations
- `Overlay.*` callsites migrated to `Scrim.*` (4 files)
- `.opacity(0.4)` disabled states to `Alpha.disabled`
- `.opacity(0.7)` muted text/icons to `Alpha.textMuted`
- `.opacity(0.2)` borders/shadows to `Alpha.border`/`Alpha.shadow`
- `.opacity(0.1)` glass tints to `Alpha.brandTintBackground`
- `CardPressStyle` 0.95 to `PressScale.standard`
- Inline `.linear(duration: 1).repeatForever` to `Motion.spinner`
- Inline `.easeInOut(duration: 2.4).repeatForever` to `Motion.float`
- File-scope `kToolbarIdleDelay` to `Timing.toolbarIdleDelay`
- `ControlsLayout` stagger `0.15 + i*0.06` to `Motion.controlsAppearDelay + i * Motion.staggerMedium`
- Empty state offset `30` and import button height `44` to their new tokens
- Hardcoded `56` navigation header to `AppSize.libraryHeader`

## Testing

- Simulator build: passes
- Device build: passes
- Installed and launched on both targets