### PR TITLE
refactor: migrate dispatchqueue hops to structured concurrency

### DIFF
--- a/ios/Empo/src/App/AppWindow.swift
+++ b/ios/Empo/src/App/AppWindow.swift
@@ -163,8 +163,8 @@ class AppWindow: UIWindow {
     private static func observePhase(window: AppWindow) {
         withObservationTracking {
             _ = AppState.shared.phase
-        } onChange: {
-            DispatchQueue.main.async { [weak window] in
+        } onChange: { [weak window] in
+            Task { @MainActor in
                 window?.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
                 if let window { observePhase(window: window) }
             }
@@ -174,8 +174,8 @@ class AppWindow: UIWindow {
     private static func observeTheme(window: AppWindow) {
         withObservationTracking {
             _ = AppSettings.shared.theme
-        } onChange: {
-            DispatchQueue.main.async { [weak window] in
+        } onChange: { [weak window] in
+            Task { @MainActor in
                 window?.overrideUserInterfaceStyle = AppSettings.shared.theme.userInterfaceStyle
                 if let window { observeTheme(window: window) }
             }

--- a/ios/Empo/src/Design/Transitions.swift
+++ b/ios/Empo/src/Design/Transitions.swift
@@ -74,7 +74,7 @@ struct StaggeredAppearance: ViewModifier {
             .offset(y: visible ? 0 : 12)
             .onChange(of: trigger) {
                 visible = false
-                DispatchQueue.main.async {
+                Task { @MainActor in
                     withAnimation(Motion.standard.delay(delay)) {
                         visible = true
                     }

--- a/ios/Empo/src/Library/GameLibrary.swift
+++ b/ios/Empo/src/Library/GameLibrary.swift
@@ -154,7 +154,7 @@ class GameLibrary {
         cancelledImports.withLock { _ = $0.remove(id) }
     }
 
-    func importGame(from sourceURL: URL, completion: @escaping (Error?) -> Void) {
+    func importGame(from sourceURL: URL, completion: @escaping @MainActor @Sendable (Error?) -> Void) {
         ensureGamesDirectory()
 
         let archiveFormat = ArchiveExtractor.Format(extension: sourceURL.pathExtension)
@@ -182,7 +182,7 @@ class GameLibrary {
             ))
         }
 
-        DispatchQueue.global(qos: .userInitiated).async {
+        Task.detached(priority: .userInitiated) {
             defer { self.clearCancellation(importID) }
             do {
                 if archiveFormat != nil {
@@ -190,7 +190,7 @@ class GameLibrary {
                 } else {
                     try self.importFolder(from: sourceURL, importID: importID)
                 }
-                DispatchQueue.main.async {
+                await MainActor.run {
                     GameLibrary.shared.reload()
                     completion(nil)
                 }
@@ -198,7 +198,7 @@ class GameLibrary {
                 NSLog("[GameLibrary] Import cancelled: %@", importID)
             } catch {
                 NSLog("[GameLibrary] Import error: %@", "\(error)")
-                DispatchQueue.main.async {
+                await MainActor.run {
                     withAnimation {
                         GameLibrary.shared.games.removeAll { $0.id == importID }
                     }
@@ -209,7 +209,7 @@ class GameLibrary {
     }
 
     nonisolated private func updateProgress(_ importID: String, _ progress: Double) {
-        DispatchQueue.main.async {
+        Task { @MainActor in
             let lib = GameLibrary.shared
             guard let idx = lib.games.firstIndex(where: { $0.id == importID }) else { return }
             lib.games[idx].status = .importing(progress: progress)
@@ -223,7 +223,7 @@ class GameLibrary {
         let artwork = GameLibrary.findArtwork(at: gameDir)
         guard title != nil || artwork != nil else { return title }
 
-        DispatchQueue.main.async {
+        Task { @MainActor in
             let lib = GameLibrary.shared
             guard let idx = lib.games.firstIndex(where: { $0.id == importID }) else { return }
             withAnimation {
@@ -310,7 +310,7 @@ class GameLibrary {
     }
 
 
-    func deleteGame(_ entry: GameEntry, onError: ((String) -> Void)? = nil) {
+    func deleteGame(_ entry: GameEntry, onError: (@MainActor @Sendable (String) -> Void)? = nil) {
         let wasImporting = entry.isImporting
 
         if let artworkPath = entry.artworkPath {
@@ -329,14 +329,14 @@ class GameLibrary {
         }
 
         let pathToDelete = entry.path
-        DispatchQueue.global(qos: .userInitiated).async {
+        Task.detached(priority: .userInitiated) {
             let fm = FileManager.default
             do {
                 guard fm.fileExists(atPath: pathToDelete) else { return }
                 try fm.removeItem(atPath: pathToDelete)
             } catch {
                 NSLog("[GameLibrary] Delete error: %@", "\(error)")
-                DispatchQueue.main.async {
+                await MainActor.run {
                     GameLibrary.shared.reload()
                     onError?(error.localizedDescription)
                 }

--- a/ios/Empo/src/Library/GameLibraryView.swift
+++ b/ios/Empo/src/Library/GameLibraryView.swift
@@ -291,7 +291,7 @@ struct GameLibraryView: View {
                 withAnimation(Motion.standard) {
                     settings.libraryDisplayMode = settings.libraryDisplayMode == .grid ? .list : .grid
                 }
-                DispatchQueue.main.async {
+                Task { @MainActor in
                     staggerTrigger = UUID()
                 }
             }

--- a/ios/Empo/src/Library/ImageSourcePicker.swift
+++ b/ios/Empo/src/Library/ImageSourcePicker.swift
@@ -88,7 +88,7 @@ private struct PhotoLibraryPicker: UIViewControllerRepresentable {
 
             provider.loadObject(ofClass: UIImage.self) { image, _ in
                 if let image = image as? UIImage {
-                    DispatchQueue.main.async {
+                    Task { @MainActor in
                         self.parent.onImageSelected(image)
                     }
                 }


### PR DESCRIPTION
## Summary

Tier 6b of the audit-driven refactor roadmap. Replaces all `DispatchQueue.main.async` and `DispatchQueue.global(qos:).async` call sites with structured Swift concurrency (`Task { @MainActor in }` / `Task.detached(priority:)` + `await MainActor.run`).

## Changes

### Main-thread hops (`Task { @MainActor in }`)
- `Transitions.swift` stagger re-animation in `StaggeredAppearance.onChange`
- `GameLibraryView.swift` display-mode toggle re-stagger
- `AppWindow.swift` orientation and theme observation re-arm (captures `[weak window]` at the `onChange` level so the `Task` inherits it cleanly)
- `ImageSourcePicker.swift` Photos-picker completion
- `GameLibrary.updateProgress` and `GameLibrary.updateSkeleton`

### Off-main work (`Task.detached(priority: .userInitiated)`)
- `GameLibrary.importGame` extraction + copy
- `GameLibrary.deleteGame` file removal

Completion handlers (`importGame.completion`, `deleteGame.onError`) gained `@MainActor @Sendable` annotations so they compose cleanly with the detached task and can still mutate call-site `@State`.

## Testing

- Simulator build: passes, no new warnings
- Device build: passes
- Installed and launched on both targets