### PR TITLE
fix: gate empty state on validation, handle disk space, show progress and artwork mid-import

### DIFF
--- a/ios/Empo/src/Library/ArchiveExtractor.swift
+++ b/ios/Empo/src/Library/ArchiveExtractor.swift
@@ -12,11 +12,17 @@ enum ArchiveExtractor {
         case readFailed(String)
         case writeFailed(String)
         case pathEscape(String)
+        /// Thrown when the caller's `shouldCancel` closure returns
+        /// `true` between libarchive entry reads. Callers use this
+        /// to distinguish a user cancel from a genuine error.
+        case cancelled
 
         var errorDescription: String? {
             switch self {
             case .openFailed(let s), .readFailed(let s), .writeFailed(let s), .pathEscape(let s):
                 return s
+            case .cancelled:
+                return "Cancelled"
             }
         }
     }
@@ -39,12 +45,111 @@ enum ArchiveExtractor {
     }
 
 
+    /// Extract only entries matching `include` from `archiveURL` into
+    /// `destDir`. Used by the import pre-flight to pull a small,
+    /// targeted subset of the archive (e.g. the `.ini` + scripts
+    /// files) for validation without paying the cost of a full
+    /// extract.
+    ///
+    /// Paths passed to `include` are relative to the archive root
+    /// (same normalisation as `Peek.entries`).
+    static func extractSelective(
+        archive archiveURL: URL,
+        to destDir: URL,
+        shouldCancel: (() -> Bool)? = nil,
+        /// When non-nil and returns `true`, the walk stops after
+        /// the current entry is processed. Used by pre-flight
+        /// validation to short-circuit once the needed scripts
+        /// file has been pulled, avoiding a full walk to EOF.
+        stopWhen: (() -> Bool)? = nil,
+        include: (String) -> Bool
+    ) throws {
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: destDir.path) {
+            try fm.createDirectory(at: destDir, withIntermediateDirectories: true)
+        }
+
+        guard let reader = archive_read_new() else {
+            throw Error.openFailed("archive_read_new failed")
+        }
+        defer { archive_read_free(reader) }
+
+        archive_read_support_format_all(reader)
+        archive_read_support_filter_all(reader)
+
+        let blockSize = 10 * 1024 * 1024
+        let openResult = archiveURL.path.withCString {
+            archive_read_open_filename(reader, $0, blockSize)
+        }
+        guard openResult == ARCHIVE_OK else {
+            throw Error.openFailed(errorString(reader) ?? "Cannot open archive")
+        }
+
+        var entry: OpaquePointer?
+        while true {
+            if shouldCancel?() == true { throw Error.cancelled }
+            let headerResult = archive_read_next_header(reader, &entry)
+            if headerResult == ARCHIVE_EOF { break }
+            if headerResult == ARCHIVE_RETRY { continue }
+            if headerResult < ARCHIVE_WARN {
+                throw Error.readFailed(errorString(reader) ?? "Archive read failure")
+            }
+            guard let entry else { continue }
+
+            guard let cPath = archive_entry_pathname(entry) else {
+                archive_read_data_skip(reader)
+                continue
+            }
+            let rawName = String(cString: cPath)
+            let relative = rawName.replacingOccurrences(of: "\\", with: "/")
+            let components = relative.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+            if relative.hasPrefix("/") || components.contains("..") {
+                archive_read_data_skip(reader)
+                continue
+            }
+            if relative.isEmpty || relative.hasPrefix("__MACOSX/") || relative == ".DS_Store" {
+                archive_read_data_skip(reader)
+                continue
+            }
+
+            let fileType = archive_entry_filetype(entry)
+            let isDir = (fileType & 0o170000) == 0o040000
+            if isDir {
+                archive_read_data_skip(reader)
+                continue
+            }
+
+            if !include(relative) {
+                archive_read_data_skip(reader)
+                continue
+            }
+
+            let outURL = destDir.appendingPathComponent(relative)
+            let parent = outURL.deletingLastPathComponent()
+            if !fm.fileExists(atPath: parent.path) {
+                try? fm.createDirectory(at: parent, withIntermediateDirectories: true)
+            }
+            try writeEntry(reader: reader, to: outURL)
+
+            if stopWhen?() == true { break }
+        }
+    }
+
+
     /// Extract an archive to `destDir`. Reports progress in [0, 1] via the
     /// optional callback. The callback runs on the caller's thread.
+    ///
+    /// `onFileWritten` fires after each file is written to disk,
+    /// providing the archive-relative path and the URL on disk.
+    /// Used by the import pipeline to surface artwork early (as
+    /// soon as `Graphics/Titles/*` lands) without waiting for the
+    /// full extract to finish.
     static func extract(
         archive archiveURL: URL,
         to destDir: URL,
-        progress: ((String, Double) -> Void)? = nil
+        shouldCancel: (() -> Bool)? = nil,
+        progress: ((String, Double) -> Void)? = nil,
+        onFileWritten: ((String, URL) -> Void)? = nil
     ) throws {
         let fm = FileManager.default
         if !fm.fileExists(atPath: destDir.path) {
@@ -91,6 +196,7 @@ enum ArchiveExtractor {
 
         var entry: OpaquePointer?
         while true {
+            if shouldCancel?() == true { throw Error.cancelled }
             let headerResult = archive_read_next_header(reader, &entry)
             if headerResult == ARCHIVE_EOF { break }
             if headerResult == ARCHIVE_RETRY { continue }
@@ -139,6 +245,7 @@ enum ArchiveExtractor {
             }
 
             try writeEntry(reader: reader, to: outURL)
+            onFileWritten?(relative, outURL)
 
             entryIndex += 1
             if let progress {

--- a/ios/Empo/src/Library/GameImportValidator.swift
+++ b/ios/Empo/src/Library/GameImportValidator.swift
@@ -18,7 +18,7 @@ enum GameImportValidator {
             case .corruptZip(let detail):
                 return "Corrupt zip file: \(detail)"
             case .notAnRPGMakerGame:
-                return "This doesn't appear to be an RPG Maker game. No valid Game.ini or RGSS archive was found."
+                return "This doesn't appear to be an RPG Maker game. No recognised game configuration was found."
             case .unsupportedRuntime(let detail):
                 return detail
             case .missingScripts(let path):
@@ -30,7 +30,11 @@ enum GameImportValidator {
     }
 
 
-    /// Throws ImportError on failure.
+    /// Throws ImportError on failure. Validates a folder already
+    /// present on disk - used both for full extracted imports and
+    /// folder-based imports. For archives we peek first via
+    /// `preflightArchive` to avoid paying the full extract cost
+    /// before the user sees confirmation the game is valid.
     static func validate(_ url: URL) throws {
         let fm = FileManager.default
         guard let items = try? fm.contentsOfDirectory(atPath: url.path) else {
@@ -72,6 +76,259 @@ enum GameImportValidator {
 
         // Nothing matched — not an RPG Maker game
         throw ImportError.notAnRPGMakerGame
+    }
+
+
+    /// Pre-flight check for archive imports. Walks the archive
+    /// once (a second pass only runs when the game uses a
+    /// non-standard scripts path) and selectively extracts just
+    /// the validation files (`.ini`, `mkxp.json`, and
+    /// `Data/Scripts.*`) into `scratchDir` so the normal folder
+    /// validator can inspect them. Returns the URL of the game
+    /// root inside `scratchDir` (for the caller to read
+    /// `parseINITitle` against). Throws with a user-facing
+    /// `ImportError` if the archive isn't a supported RPG Maker
+    /// game.
+    ///
+    /// The single-walk strategy assumes RPG Maker games keep the
+    /// scripts file at the default `Data/Scripts.{rxdata,rvdata,
+    /// rvdata2}` path (which is essentially all of them). If a
+    /// game hard-codes a custom scripts path via Game.ini's
+    /// `Scripts=` key we fall through to a targeted second pass.
+    ///
+    /// Artwork is not pulled by the pre-flight: archive order
+    /// typically places `Data/Scripts.*` before `Graphics/Titles/*`,
+    /// so a walk wide enough to catch both would no longer
+    /// short-circuit on typical archives. The full-extract pass
+    /// surfaces artwork mid-flight via its per-file callback
+    /// instead.
+    @discardableResult
+    static func preflightArchive(
+        at archiveURL: URL,
+        scratchDir: URL,
+        shouldCancel: (() -> Bool)? = nil
+    ) throws -> URL {
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: scratchDir.path) {
+            try fm.createDirectory(at: scratchDir, withIntermediateDirectories: true)
+        }
+
+        // State tracked during the walk. The walk stops early
+        // when any of these prove the game is valid:
+        //   1. RGSS archive marker (`.rgssad`/`.rgss2a`/`.rgss3a`)
+        //      at the game root - its name alone is sufficient.
+        //   2. We've pulled both a root `.ini`/`mkxp.json` AND a
+        //      `Data/Scripts.*` file. Between them the folder
+        //      validator has everything it needs - no point
+        //      walking the rest of a 700MB archive just to hit
+        //      EOF.
+        var rgssArchiveVersion: RGSSVersion?
+        var sawMetadata = false
+        var sawScripts = false
+
+        do {
+            try ArchiveExtractor.extractSelective(
+                archive: archiveURL,
+                to: scratchDir,
+                shouldCancel: shouldCancel,
+                stopWhen: {
+                    rgssArchiveVersion != nil || (sawMetadata && sawScripts)
+                }
+            ) { path in
+                let components = path.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+                // `depth` counts how many folder hops away from the
+                // archive root the entry sits. We accept files at
+                // depth 0 (flat archive) and depth 1 (wrapper
+                // folder) for metadata; scripts files live one
+                // deeper because they're inside Data/.
+                let depth = components.count - 1
+                guard let name = components.last?.lowercased() else { return false }
+
+                // Game root metadata files.
+                if depth <= 1 {
+                    if name.hasSuffix(".ini") || name == "mkxp.json" {
+                        sawMetadata = true
+                        return true
+                    }
+                    if name.hasSuffix(".rgssad") {
+                        rgssArchiveVersion = .xp
+                        return false
+                    }
+                    if name.hasSuffix(".rgss2a") {
+                        rgssArchiveVersion = .vx
+                        return false
+                    }
+                    if name.hasSuffix(".rgss3a") {
+                        rgssArchiveVersion = .vxAce
+                        return false
+                    }
+                }
+
+                // Speculative scripts extraction: catches the
+                // default `Data/Scripts.*` layout. Games with a
+                // custom Scripts= path fall through to the second
+                // pass below.
+                if depth == 1 || depth == 2 {
+                    let parent = components.count >= 2 ? components[components.count - 2].lowercased() : ""
+                    if parent == "data",
+                       name.hasPrefix("scripts."),
+                       name.hasSuffix(".rxdata") || name.hasSuffix(".rvdata") || name.hasSuffix(".rvdata2") {
+                        sawScripts = true
+                        return true
+                    }
+                }
+
+                // Artwork is deliberately NOT extracted here.
+                // Archives tend to be alphabetical, putting
+                // `Data/Scripts.*` before `Graphics/Titles/*`, so
+                // the walk's `stopWhen` predicate would fire before
+                // any artwork is reached. The full-extract pass
+                // later surfaces artwork via its per-file callback.
+
+                return false
+            }
+        } catch ArchiveExtractor.Error.cancelled {
+            throw ArchiveExtractor.Error.cancelled
+        } catch {
+            throw ImportError.corruptZip(error.localizedDescription)
+        }
+
+        // Determine where the game root landed inside scratchDir
+        // based on what actually got extracted (matches the
+        // post-extraction logic that the full import uses later).
+        let gameRoot = findGameRoot(in: scratchDir, fm: fm)
+
+        // Fast path: RGSS-archived games were identified by name
+        // during the walk.
+        if let version = rgssArchiveVersion {
+            try checkRuntimeSupport(version)
+            return gameRoot
+        }
+
+        // Parse any extracted .ini for its `Scripts=` key.
+        var scriptsPath: String?
+        var detectedVersion: RGSSVersion?
+        if let items = try? fm.contentsOfDirectory(atPath: gameRoot.path) {
+            for item in items where item.lowercased().hasSuffix(".ini") {
+                let iniURL = gameRoot.appendingPathComponent(item)
+                if let (version, path) = parseIniScripts(iniURL) {
+                    detectedVersion = version
+                    scriptsPath = path
+                    break
+                }
+            }
+        }
+
+        // Fall back to mkxp.json's customScript when no ini
+        // yielded a scripts path.
+        var customScriptPath: String?
+        let mkxpURL = gameRoot.appendingPathComponent("mkxp.json")
+        if scriptsPath == nil, fm.fileExists(atPath: mkxpURL.path) {
+            customScriptPath = Self.customScriptPath(gameRoot)
+            if customScriptPath == nil {
+                throw ImportError.notAnRPGMakerGame
+            }
+            detectedVersion = rgssVersionFromMkxpJson(gameRoot)
+        }
+
+        guard scriptsPath != nil || customScriptPath != nil else {
+            throw ImportError.notAnRPGMakerGame
+        }
+
+        if let detectedVersion {
+            try checkRuntimeSupport(detectedVersion)
+        }
+
+        // Validate the scripts/customScript file. Usually already
+        // on disk from the single walk; second pass only runs when
+        // the game uses a non-standard path.
+        if let scriptsPath {
+            let normalized = scriptsPath.replacingOccurrences(of: "\\", with: "/")
+            try ensureFileExtracted(
+                relativePath: normalized,
+                gameRoot: gameRoot,
+                archiveURL: archiveURL,
+                scratchDir: scratchDir,
+                shouldCancel: shouldCancel
+            )
+            try validateRGSSScripts(at: gameRoot, scriptsPath: normalized)
+        } else if let customScriptPath {
+            let normalized = customScriptPath.replacingOccurrences(of: "\\", with: "/")
+            try ensureFileExtracted(
+                relativePath: normalized,
+                gameRoot: gameRoot,
+                archiveURL: archiveURL,
+                scratchDir: scratchDir,
+                shouldCancel: shouldCancel
+            )
+            try validateCustomScript(at: gameRoot, scriptPath: normalized)
+        }
+
+        return gameRoot
+    }
+
+
+    /// Ensures `gameRoot/relativePath` exists on disk, running a
+    /// targeted second archive walk only when the speculative
+    /// first walk didn't pull the file. Handles both flat and
+    /// single-wrapper archives by stripping the wrapper from
+    /// archive paths before matching.
+    private static func ensureFileExtracted(
+        relativePath: String,
+        gameRoot: URL,
+        archiveURL: URL,
+        scratchDir: URL,
+        shouldCancel: (() -> Bool)?
+    ) throws {
+        let fm = FileManager.default
+        let expected = gameRoot.appendingPathComponent(relativePath)
+        if fm.fileExists(atPath: expected.path) { return }
+
+        let wrapperPrefix: String? = gameRoot == scratchDir
+            ? nil
+            : gameRoot.lastPathComponent + "/"
+
+        var extracted = false
+        try ArchiveExtractor.extractSelective(
+            archive: archiveURL,
+            to: scratchDir,
+            shouldCancel: shouldCancel,
+            stopWhen: { extracted }
+        ) { rawPath in
+            let archivePath = rawPath.replacingOccurrences(of: "\\", with: "/")
+            let gameRelative: String
+            if let prefix = wrapperPrefix {
+                guard archivePath.hasPrefix(prefix) else { return false }
+                gameRelative = String(archivePath.dropFirst(prefix.count))
+            } else {
+                gameRelative = archivePath
+            }
+            let match = gameRelative.caseInsensitiveCompare(relativePath) == .orderedSame
+            if match { extracted = true }
+            return match
+        }
+    }
+
+
+    /// Determine the effective game root inside `scratchDir`. If
+    /// exactly one directory sits at the top (ignoring macOS
+    /// metadata), that directory is the wrapper; otherwise files
+    /// are flat inside `scratchDir` itself. Mirrors the logic used
+    /// by `GameLibrary.findGameRoot` after full extraction.
+    private static func findGameRoot(in scratchDir: URL, fm: FileManager) -> URL {
+        guard let items = try? fm.contentsOfDirectory(
+            at: scratchDir,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else { return scratchDir }
+
+        let meaningful = items.filter { $0.lastPathComponent != "__MACOSX" }
+        if meaningful.count == 1,
+           let single = meaningful.first,
+           (try? single.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true {
+            return single
+        }
+        return scratchDir
     }
 
 

--- a/ios/Empo/src/Library/GameLibrary.swift
+++ b/ios/Empo/src/Library/GameLibrary.swift
@@ -4,11 +4,45 @@ import SwiftUI
 import Observation
 import Synchronization
 
+/// In-flight import that's still in its pre-flight validation phase.
+/// Once the pre-flight passes, the matching `GameEntry` is appended
+/// to `games` with `.importing(progress:)` status and the pending
+/// entry is cleared - progress from that point on lives on the real
+/// game card/row. On any pre-flight failure, the pending entry is
+/// dropped without the user ever seeing a half-broken skeleton.
+///
+/// Rendering of the validating state is delegated to the call site:
+/// when the library is empty the Import button hoists it onto its
+/// own label; when the library already has games the grid/list
+/// renders a synthetic card via `syntheticEntry` so the status
+/// feedback stays anchored where the user expects it.
+struct PendingImport: Identifiable, Hashable {
+    let id: String
+    let sourceName: String
+
+    /// Placeholder `GameEntry` used when rendering the pending
+    /// import inside the existing grid/list. Path is empty because
+    /// nothing is on disk yet; `progress: 0` renders as the
+    /// indeterminate spinner inside `GameStatusIndicator`, which is
+    /// the right visual read for the pre-flight validation phase.
+    var syntheticEntry: GameEntry {
+        GameEntry(
+            id: id,
+            path: "",
+            title: sourceName,
+            artworkPath: nil,
+            status: .importing(progress: 0)
+        )
+    }
+}
+
+
 @MainActor @Observable
 class GameLibrary {
     static let shared = GameLibrary()
 
     var games: [GameEntry] = []
+    var pendingImports: [String: PendingImport] = [:]
 
     private let fm = FileManager.default
     private let cancelledImports = Mutex(Set<String>())
@@ -142,6 +176,35 @@ class GameLibrary {
 
     private struct ImportCancelled: Error {}
 
+    /// Errors surfaced from the import pipeline with display-ready
+    /// messages. Used to remap low-level Foundation errors (disk
+    /// full, permission denied) into text the user can act on.
+    enum ImportError: LocalizedError {
+        case outOfSpace
+
+        var errorDescription: String? {
+            switch self {
+            case .outOfSpace:
+                return "Not enough space to import. Free up space on your device and try again."
+            }
+        }
+    }
+
+    /// True when `error` is the Foundation / POSIX flavor of "disk
+    /// full". Covers both `NSFileWriteOutOfSpaceError` (from
+    /// FileManager writes) and `ENOSPC` (from libc-level calls that
+    /// libarchive bubbles up as NSError).
+    nonisolated private static func isOutOfSpace(_ error: Error) -> Bool {
+        let ns = error as NSError
+        if ns.domain == NSCocoaErrorDomain && ns.code == NSFileWriteOutOfSpaceError {
+            return true
+        }
+        if ns.domain == NSPOSIXErrorDomain && ns.code == Int(ENOSPC) {
+            return true
+        }
+        return false
+    }
+
     nonisolated private func isImportCancelled(_ id: String) -> Bool {
         cancelledImports.withLock { $0.contains(id) }
     }
@@ -154,41 +217,36 @@ class GameLibrary {
         cancelledImports.withLock { _ = $0.remove(id) }
     }
 
+    /// Cancel an import that's still in its pre-validation phase
+    /// (visible only via `pendingImports`). The detached task sees
+    /// the cancellation flag at its next checkpoint, unwinds temp
+    /// files, and removes the pending entry.
+    func cancelPendingImport(_ importID: String) {
+        cancelImport(importID)
+    }
+
     func importGame(from sourceURL: URL, completion: @escaping @MainActor @Sendable (Error?) -> Void) {
         ensureGamesDirectory()
 
         let archiveFormat = ArchiveExtractor.Format(extension: sourceURL.pathExtension)
         let importID = UUID().uuidString
+        let sourceName = archiveFormat == nil
+            ? sourceURL.lastPathComponent
+            : sourceURL.deletingPathExtension().lastPathComponent
 
-        let title: String
-        let artwork: String?
-        if archiveFormat == nil {
-            title = GameEntry.parseINITitle(at: sourceURL) ?? sourceURL.lastPathComponent
-            artwork = Self.findArtwork(at: sourceURL)
-        } else {
-            title = sourceURL.deletingPathExtension().lastPathComponent
-            artwork = nil
-        }
-
-        // Skeleton card uses the same ID as the final entry, so SwiftUI
-        // animates in-place when reload() provides the real data.
-        withAnimation {
-            games.append(GameEntry(
-                id: importID,
-                path: "",
-                title: title,
-                artworkPath: artwork,
-                status: .importing(progress: 0)
-            ))
-        }
+        // Pre-flight phase: button shows "Validating", library keeps
+        // its current UI (empty state or existing list). Once
+        // pre-flight passes we commit a progress card to `games` and
+        // extraction/finalisation runs with the card visible.
+        pendingImports[importID] = PendingImport(id: importID, sourceName: sourceName)
 
         Task.detached(priority: .userInitiated) {
             defer { self.clearCancellation(importID) }
             do {
                 if archiveFormat != nil {
-                    try self.importArchive(from: sourceURL, importID: importID)
+                    try self.importArchive(from: sourceURL, importID: importID, sourceName: sourceName)
                 } else {
-                    try self.importFolder(from: sourceURL, importID: importID)
+                    try self.importFolder(from: sourceURL, importID: importID, sourceName: sourceName)
                 }
                 await MainActor.run {
                     GameLibrary.shared.reload()
@@ -196,47 +254,80 @@ class GameLibrary {
                 }
             } catch is ImportCancelled {
                 NSLog("[GameLibrary] Import cancelled: %@", importID)
+                await MainActor.run {
+                    _ = GameLibrary.shared.pendingImports.removeValue(forKey: importID)
+                    GameLibrary.shared.games.removeAll { $0.id == importID }
+                }
             } catch {
                 NSLog("[GameLibrary] Import error: %@", "\(error)")
+                let surfaced: Error = Self.isOutOfSpace(error) ? ImportError.outOfSpace : error
                 await MainActor.run {
-                    withAnimation {
-                        GameLibrary.shared.games.removeAll { $0.id == importID }
-                    }
-                    completion(error)
+                    _ = GameLibrary.shared.pendingImports.removeValue(forKey: importID)
+                    GameLibrary.shared.games.removeAll { $0.id == importID }
+                    completion(surfaced)
                 }
             }
         }
     }
 
-    nonisolated private func updateProgress(_ importID: String, _ progress: Double) {
+    /// Commits a progress-card `GameEntry` to `games` and drops the
+    /// matching pending entry. Called from the import pipeline once
+    /// pre-flight validation passes - from this point on the user
+    /// can see and cancel the import from the card itself.
+    nonisolated private func commitPendingToCard(_ importID: String, title: String, artworkPath: String?) {
+        Task { @MainActor in
+            let lib = GameLibrary.shared
+            withAnimation {
+                _ = lib.pendingImports.removeValue(forKey: importID)
+                lib.games.append(GameEntry(
+                    id: importID,
+                    path: "",
+                    title: title,
+                    artworkPath: artworkPath,
+                    status: .importing(progress: 0)
+                ))
+            }
+        }
+    }
+
+    /// Swap in the card's artwork mid-extract, once the archive
+    /// has yielded a `Graphics/Titles/*` image. Called more than
+    /// once per import: each time the extractor finds an
+    /// alphabetically-smaller candidate the card updates to
+    /// match, mirroring the rule used by `findArtwork` after the
+    /// full extract completes so the card doesn't flicker to a
+    /// different artwork when the import finishes. Rebuilding the
+    /// entry (rather than mutating `artworkPath` on the existing
+    /// one) goes through SwiftUI's normal diffing so the card
+    /// cross-fades the placeholder to the real artwork.
+    nonisolated private func updateCardArtwork(_ importID: String, artworkPath: String) {
+        Task { @MainActor in
+            let lib = GameLibrary.shared
+            guard let idx = lib.games.firstIndex(where: { $0.id == importID }) else { return }
+            guard lib.games[idx].artworkPath != artworkPath else { return }
+            withAnimation {
+                lib.games[idx] = GameEntry(
+                    id: importID,
+                    path: lib.games[idx].path,
+                    title: lib.games[idx].title,
+                    artworkPath: artworkPath,
+                    originalTitle: lib.games[idx].originalTitle,
+                    lastPlayed: lib.games[idx].lastPlayed,
+                    status: lib.games[idx].status
+                )
+            }
+        }
+    }
+
+    /// Updates the extraction progress on the already-committed
+    /// progress card (not on `pendingImports`, which was cleared
+    /// once pre-flight passed).
+    nonisolated private func updateCardProgress(_ importID: String, _ progress: Double) {
         Task { @MainActor in
             let lib = GameLibrary.shared
             guard let idx = lib.games.firstIndex(where: { $0.id == importID }) else { return }
             lib.games[idx].status = .importing(progress: progress)
         }
-    }
-
-    /// Updates the skeleton card's title and artwork mid-import (e.g. after zip extraction).
-    @discardableResult
-    nonisolated private func updateSkeleton(_ importID: String, gameDir: URL) -> String? {
-        let title = GameEntry.parseINITitle(at: gameDir)
-        let artwork = GameLibrary.findArtwork(at: gameDir)
-        guard title != nil || artwork != nil else { return title }
-
-        Task { @MainActor in
-            let lib = GameLibrary.shared
-            guard let idx = lib.games.firstIndex(where: { $0.id == importID }) else { return }
-            withAnimation {
-                lib.games[idx] = GameEntry(
-                    id: importID,
-                    path: "",
-                    title: title ?? lib.games[idx].title,
-                    artworkPath: artwork ?? lib.games[idx].artworkPath,
-                    status: .importing(progress: lib.games[idx].importProgress)
-                )
-            }
-        }
-        return title
     }
 
     nonisolated private func destinationURL(for importID: String, title: String?) -> URL {
@@ -245,7 +336,7 @@ class GameLibrary {
         return Self.gamesDirectory.appendingPathComponent(folderName)
     }
 
-    nonisolated private func importFolder(from sourceURL: URL, importID: String) throws {
+    nonisolated private func importFolder(from sourceURL: URL, importID: String, sourceName: String) throws {
         let fm = FileManager.default
         let folderName = sourceURL.lastPathComponent
 
@@ -254,53 +345,152 @@ class GameLibrary {
         try fm.createDirectory(at: tmpDir, withIntermediateDirectories: true)
         defer { try? fm.removeItem(at: tmpDir) }
 
+        // Pre-flight: copy once into tmp (cheaper than moving the
+        // source and having no rollback if validation fails) and
+        // validate the copy. This is the only "Validating" phase
+        // the user sees on the button.
         try fm.copyItem(at: sourceURL, to: tmpDest)
         guard !isImportCancelled(importID) else { throw ImportCancelled() }
 
         try GameImportValidator.validate(tmpDest)
         guard !isImportCancelled(importID) else { throw ImportCancelled() }
 
-        let title = GameEntry.parseINITitle(at: tmpDest)
+        // Pre-flight passed - commit the progress card so the rest
+        // of the import has a visible home for progress/cancel UI.
+        let title = GameEntry.parseINITitle(at: tmpDest) ?? sourceName
+        let artworkPath = Self.findArtwork(at: tmpDest)
+        if let path = artworkPath {
+            // Warm the decode cache before `tmpDest`'s defer-backed
+            // cleanup kicks in so the card keeps rendering the
+            // artwork across the move-then-reload window.
+            _ = ImageCache.shared.image(for: path)
+        }
+        commitPendingToCard(importID, title: title, artworkPath: artworkPath)
+
+        // Folder imports don't have a meaningful extraction-progress
+        // phase (the heavy copy already happened in the pre-flight).
+        // Jump directly to the move; if the card gets cancelled in
+        // the brief window before the move finishes, the cancel
+        // path below cleans up.
+        updateCardProgress(importID, 1.0)
+
         let destURL = destinationURL(for: importID, title: title)
         try fm.moveItem(at: tmpDest, to: destURL)
 
-        // If cancelled right after move, clean up the destination
-        if isImportCancelled(importID) {
-            try? fm.removeItem(at: destURL)
-            throw ImportCancelled()
+        var committed = false
+        defer {
+            if !committed {
+                try? fm.removeItem(at: destURL)
+            }
         }
 
-        // Create initial metadata
+        if isImportCancelled(importID) { throw ImportCancelled() }
         GameLibrary.createMetadata(for: importID)
+        committed = true
     }
 
-    nonisolated private func importArchive(from sourceURL: URL, importID: String) throws {
+    nonisolated private func importArchive(from sourceURL: URL, importID: String, sourceName: String) throws {
         let fm = FileManager.default
+
+        // Pre-flight scratch: throwaway dir where we selectively
+        // extract just the validation files. Lives only for the
+        // length of the pre-flight phase.
+        let preflightDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(at: preflightDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: preflightDir) }
+
+        let preflightRoot: URL
+        do {
+            preflightRoot = try GameImportValidator.preflightArchive(
+                at: sourceURL,
+                scratchDir: preflightDir,
+                shouldCancel: { self.isImportCancelled(importID) }
+            )
+        } catch ArchiveExtractor.Error.cancelled {
+            throw ImportCancelled()
+        }
+        guard !isImportCancelled(importID) else { throw ImportCancelled() }
+
+        // Pre-flight passed - pick up the title we learned from
+        // the extracted `.ini` so the committed card shows the
+        // real name while the rest of the archive extracts in the
+        // background. Artwork fills in mid-extract via the
+        // extract() callback below.
+        let title = GameEntry.parseINITitle(at: preflightRoot) ?? sourceName
+        commitPendingToCard(importID, title: title, artworkPath: nil)
+
+        // Full extraction now runs visibly - progress feeds the
+        // committed card's `.importing(progress:)` status.
         let tmpDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try fm.createDirectory(at: tmpDir, withIntermediateDirectories: true)
         defer { try? fm.removeItem(at: tmpDir) }
 
-        try ArchiveExtractor.extract(archive: sourceURL, to: tmpDir) { _, pct in
-            self.updateProgress(importID, pct)
+        // Mid-extract artwork surfacing. `findArtwork` picks the
+        // alphabetically-smallest image under `Graphics/Titles/`,
+        // so we mirror that rule here by keeping the smallest
+        // filename we've seen and updating the card every time a
+        // smaller one comes through. This guarantees the card's
+        // artwork matches what the post-reload card will show
+        // (otherwise the card would swap to a different image
+        // once the import finished, which looks like a flicker).
+        let bestArtworkFilename = Mutex<String?>(nil)
+        do {
+            try ArchiveExtractor.extract(
+                archive: sourceURL,
+                to: tmpDir,
+                shouldCancel: { self.isImportCancelled(importID) },
+                progress: { _, pct in
+                    self.updateCardProgress(importID, pct)
+                },
+                onFileWritten: { relative, diskURL in
+                    // Accept any image under a `Graphics/Titles/`
+                    // folder regardless of depth (handles flat and
+                    // single-wrapper archives alike).
+                    let lower = relative.lowercased()
+                    guard lower.contains("graphics/titles/") else { return }
+                    let ext = (relative as NSString).pathExtension.lowercased()
+                    guard ["png", "jpg", "jpeg", "bmp"].contains(ext) else { return }
+
+                    let filename = (relative as NSString).lastPathComponent
+                    let shouldUpdate = bestArtworkFilename.withLock { best -> Bool in
+                        if let current = best, current <= filename { return false }
+                        best = filename
+                        return true
+                    }
+                    guard shouldUpdate else { return }
+
+                    // The file is at `diskURL` right now, but
+                    // `tmpDir` will be swept after the full
+                    // extract+move completes. Warm the decode
+                    // cache at that path so the card renders the
+                    // cached UIImage even after the file moves
+                    // (the NSCache entry survives; the subsequent
+                    // reload() points the card at the permanent
+                    // `destURL/Graphics/Titles/*` and reads fresh
+                    // from there).
+                    _ = ImageCache.shared.image(for: diskURL.path)
+                    self.updateCardArtwork(importID, artworkPath: diskURL.path)
+                }
+            )
+        } catch ArchiveExtractor.Error.cancelled {
+            throw ImportCancelled()
         }
         guard !isImportCancelled(importID) else { throw ImportCancelled() }
 
         let gameRoot = try GameLibrary.findGameRoot(in: tmpDir)
-        let title = updateSkeleton(importID, gameDir: gameRoot)
-        try GameImportValidator.validate(gameRoot)
-        guard !isImportCancelled(importID) else { throw ImportCancelled() }
-
         let destURL = destinationURL(for: importID, title: title)
         try fm.moveItem(at: gameRoot, to: destURL)
 
-        // If cancelled right after move, clean up the destination
-        if isImportCancelled(importID) {
-            try? fm.removeItem(at: destURL)
-            throw ImportCancelled()
+        var committed = false
+        defer {
+            if !committed {
+                try? fm.removeItem(at: destURL)
+            }
         }
 
-        // Create initial metadata
+        if isImportCancelled(importID) { throw ImportCancelled() }
         GameLibrary.createMetadata(for: importID)
+        committed = true
     }
 
     nonisolated private static func createMetadata(for gameId: String) {

--- a/ios/Empo/src/Library/GameLibraryView.swift
+++ b/ios/Empo/src/Library/GameLibraryView.swift
@@ -19,6 +19,7 @@ struct GameLibraryView: View {
     @State private var errorMessage: String?
     @State private var errorTitle: String = "Oops!"
     @State private var showErrorAlert = false
+    @State private var showCancelValidationAlert = false
     @State private var gameToDelete: GameEntry?
     @State private var showDeleteConfirm = false
     @State private var showInvalidAlert = false
@@ -52,6 +53,18 @@ struct GameLibraryView: View {
             ? library.games
             : library.games.filter { $0.title.localizedCaseInsensitiveContains(searchText) }
         return GameSorting.sort(base, option: settings.librarySortOption, sizes: gameSizes)
+    }
+
+    /// Synthetic cards for pre-flight validations, pinned to the top
+    /// of the grid/list. These only render when the library is
+    /// already populated - the empty-state flow keeps validation
+    /// feedback on the Import button so the empty state doesn't
+    /// bounce in and out on invalid imports.
+    private var pendingValidationEntries: [GameEntry] {
+        guard !library.games.isEmpty else { return [] }
+        return library.pendingImports.values
+            .sorted { $0.id < $1.id }
+            .map(\.syntheticEntry)
     }
 
     private var showEmpty: Bool {
@@ -152,7 +165,13 @@ struct GameLibraryView: View {
                     entranceDelay: entranceDelay,
                     headerHeight: headerHeight,
                     emptyStateHeight: emptyStateHeight,
-                    emptyStateOffset: -AppSize.emptyStateOffset
+                    emptyStateOffset: -AppSize.emptyStateOffset,
+                    // Only the empty-state Import button shows a
+                    // validating label. When the library already has
+                    // games, pre-flight feedback lives on the grid/list
+                    // cards instead (see pendingValidationEntries).
+                    isValidating: showEmpty && !library.pendingImports.isEmpty,
+                    onRequestCancelValidation: { showCancelValidationAlert = true }
                 )
             }
             .toolbarVisibility(.hidden, for: .navigationBar)
@@ -198,6 +217,16 @@ struct GameLibraryView: View {
                 Button("OK") {}
             } message: {
                 Text("This game couldn't be loaded properly. You can delete it and try importing again.")
+            }
+            .alert("Cancel import?", isPresented: $showCancelValidationAlert) {
+                Button("Keep importing", role: .cancel) {}
+                Button("Cancel import", role: .destructive) {
+                    for id in library.pendingImports.keys {
+                        library.cancelPendingImport(id)
+                    }
+                }
+            } message: {
+                Text("The game is still being validated. Cancelling will stop the import.")
             }
             .alert("A game is paused", isPresented: $showPausedGameAlert) {
                 Button("Cancel", role: .cancel) {
@@ -393,6 +422,15 @@ struct GameLibraryView: View {
                 librarySectionHeader
             }
 
+            ForEach(pendingValidationEntries, id: \.id) { pending in
+                GameListRow(
+                    game: pending,
+                    onStopImport: { showCancelValidationAlert = true }
+                )
+                .id("\(pending.id)-pending")
+                .transition(.cardAppear)
+            }
+
             ForEach(Array(filteredGames.enumerated()), id: \.element.id) { index, game in
                 let isPaused = pauseManager.pausedGame?.id == game.id
                 Button {
@@ -426,10 +464,20 @@ struct GameLibraryView: View {
         .padding(.horizontal)
         .padding(.top, Spacing.lg)
         .animation(Motion.standard, value: filteredGames)
+        .animation(Motion.standard, value: pendingValidationEntries)
     }
 
     @ViewBuilder
     private var gridItems: some View {
+        ForEach(pendingValidationEntries, id: \.id) { pending in
+            GameCard(
+                game: pending,
+                onStopImport: { showCancelValidationAlert = true }
+            )
+            .id("\(pending.id)-pending")
+            .transition(.cardAppear)
+        }
+
         ForEach(Array(filteredGames.enumerated()), id: \.element.id) { index, game in
             switch game.status {
             case .importing:

--- a/ios/Empo/src/Library/ImportButton.swift
+++ b/ios/Empo/src/Library/ImportButton.swift
@@ -8,11 +8,19 @@ struct ImportButton: View {
     var headerHeight: CGFloat
     var emptyStateHeight: CGFloat
     var emptyStateOffset: CGFloat
+    /// True while one or more pre-flight validations are running.
+    /// During this window the button swaps its "Import game" label
+    /// for a "Validating" spinner and taps prompt a cancel
+    /// confirmation instead of opening the picker.
+    var isValidating: Bool = false
+    var onRequestCancelValidation: (() -> Void)? = nil
 
     @State private var importShimmer: CGFloat = -1
     @State private var importMoveTrigger = 0
     @State private var buttonHeight: CGFloat = AppSize.minTapTarget
     @State private var revealed = false
+
+
 
     var body: some View {
         GeometryReader { geo in
@@ -42,7 +50,13 @@ struct ImportButton: View {
             let endAngle = atan2(collapsedY - arcCenterY, collapsedX - arcCenterX)
             let arcDeg = (endAngle - startAngle) * 180 / .pi
 
-            Button(action: { showImporter = true }) {
+            Button(action: {
+                if isValidating {
+                    onRequestCancelValidation?()
+                } else {
+                    showImporter = true
+                }
+            }) {
                 importButtonLabel(collapsed: collapsed)
             }
             .buttonStyle(.plain)
@@ -96,6 +110,7 @@ struct ImportButton: View {
             .position(x: arcCenterX, y: arcCenterY)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .animation(.spring(duration: 0.25, bounce: 0.15), value: showEmpty)
+            .animation(Motion.standard, value: isValidating)
             .onChange(of: showEmpty) { importMoveTrigger += 1 }
             .onAppear {
                 if splashDismissed {
@@ -121,9 +136,12 @@ struct ImportButton: View {
     @ViewBuilder
     private func importButtonLabel(collapsed: Bool) -> some View {
         HStack(spacing: Spacing.md) {
-            Image(systemName: "plus")
+            importButtonIcon
+                .id(isValidating ? "validating" : "idle")
+                .transition(.blurReplace)
             if !collapsed {
-                Text("Import game")
+                Text(isValidating ? "Validating" : "Import game")
+                    .contentTransition(.numericText())
                     .transition(.blurReplace)
             }
         }
@@ -138,6 +156,15 @@ struct ImportButton: View {
         )
         .glassEffect(.regular.tint(.brand).interactive(), in: .capsule)
         .darkGlass()
+    }
+
+    @ViewBuilder
+    private var importButtonIcon: some View {
+        if isValidating {
+            SpinnerRing(progress: 0, size: 18, lineWidth: 2)
+        } else {
+            Image(systemName: "plus")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes three import-flow issues and restructures the pipeline so the user gets feedback immediately instead of waiting for full extraction.

## Empty-state gate

The empty state previously flickered out as soon as a skeleton card was appended, and rolled back when validation failed on an invalid archive. Now the library stays in its empty state until pre-flight validation passes. Only after the import is confirmed valid does the empty state animate out and a real card appear.

## Disk space handling

`NSFileWriteOutOfSpaceError` and POSIX `ENOSPC` now remap to a user-facing "Not enough space to import" alert instead of an opaque Foundation message. `importFolder` / `importArchive` gained `committed` defer guards so any throw after `moveItem` removes the partial write from `Games/` instead of orphaning it.

## Import pipeline restructure

- **New pre-flight phase**: `GameImportValidator.preflightArchive` walks the archive once (a second pass only runs when the game uses a non-standard scripts path) and selectively extracts just `.ini`, `mkxp.json`, and `Data/Scripts.*`. Short-circuits as soon as an RGSS-archive marker or both a metadata + scripts file have been extracted, so large archives like Pokemon Z no longer traverse to EOF.
- **Button states simplified to idle/validating**: Empty-library path shows "Validating" on the Import button during pre-flight; populated-library path renders a synthetic card at the top of the grid/list with an indeterminate spinner.
- **Cancel confirmation**: Tapping either the validating button or the synthetic card's stop button shows a "Cancel import?" confirmation alert before actually cancelling.
- **Cancellable archive walks**: `ArchiveExtractor.extract`/`extractSelective` accept a `shouldCancel` closure checked between entries so long extractions respond to cancel immediately instead of running to completion.

## Progress and artwork surface early

- Progress card commits to the library as soon as pre-flight passes; the rest of the extraction runs behind the card's progress ring.
- Title is pulled from the extracted `.ini` at commit time so the card shows the real game name instead of the source filename.
- **Artwork surfaces mid-extract**: new `onFileWritten` callback on `ArchiveExtractor.extract` fires per-file. The import hook watches for any image under `Graphics/Titles/*`, tracks the alphabetically-smallest filename seen (matching `findArtwork`'s post-reload rule), and swaps the card's artwork in place whenever a smaller match arrives. The `ImageCache` is warmed at the temp path so the decoded `UIImage` survives the move + reload window.

## Copy tweak

"No valid Game.ini or RGSS archive was found" -> "No recognised game configuration was found" since games routinely rename their `.ini` to something other than `Game.ini`.

## Testing

- Simulator build: passes
- Device build: passes
- Verified on device with Pokemon Z (700 MB zip), Pokemon Uranium, BTTheManor.