### PR TITLE
feat: extract game icon from .exe as primary artwork source

### DIFF
--- a/ios/Empo/src/Library/ExecutableIconExtractor.swift
+++ b/ios/Empo/src/Library/ExecutableIconExtractor.swift
@@ -1,0 +1,713 @@
+import Foundation
+import UIKit
+
+
+/// Extracts the embedded icon from a Windows PE executable
+/// (`Game.exe` and friends) and returns it as a `UIImage`. Used as
+/// the primary artwork source for imported RPG Maker games: the
+/// developer-authored `.exe` icon is closer to "official artwork"
+/// than the first image under `Graphics/Titles/`, which is usually
+/// a title-screen still.
+///
+/// The parser is intentionally narrow: it only touches the parts
+/// of the PE format needed to reach the resource section and the
+/// import table. Icons come from `RT_GROUP_ICON` + `RT_ICON`
+/// resources, reassembled into a standalone `.ico` blob for
+/// `UIImage(data:)`. The import table is consulted so that in
+/// games which ship multiple executables (e.g. Pokemon Uranium's
+/// `Uranium.exe` + `Patcher.exe`) we pick the one that actually
+/// imports `RGSS*.dll` and skip updater / installer binaries.
+///
+/// Anything unexpected (bad signatures, truncated data, overflows)
+/// returns nil rather than throwing so the caller can fall back to
+/// its existing artwork-resolution rules.
+enum ExecutableIconExtractor {
+
+    /// Sidecar filename written next to a game's files so the
+    /// library scan picks up the already-decoded PE icon without
+    /// re-parsing the `.exe` on every reload.
+    static let sidecarFilename = ".empo-artwork.png"
+
+
+    /// Substrings commonly found in bundled helper binaries
+    /// (patchers, updaters, installers, launchers, RTP installers).
+    /// An `.exe` whose filename contains any of these is treated
+    /// as an auxiliary tool and skipped, even when it has an
+    /// icon. Match is case-insensitive.
+    ///
+    /// Not exhaustive but good enough for the RPG Maker ecosystem:
+    /// most "main binary vs. side tool" ambiguities come from a
+    /// handful of well-known naming patterns (Pokemon Uranium's
+    /// `Patcher.exe`, many fan games' `Launcher.exe`, RTP
+    /// `Setup.exe`, etc.).
+    private static let utilityKeywords: [String] = [
+        "patcher", "patch",
+        "updater", "update",
+        "installer", "install",
+        "unins",      // InnoSetup uninstallers (unins000.exe)
+        "config", "configure",
+        "setup",
+        "editor",
+        "rtp",
+        "dxwebsetup", "vcredist",
+    ]
+
+
+    /// True when `filename` matches a known auxiliary-tool naming
+    /// pattern. Used by both the import-time extractor and the
+    /// post-reload sidecar writer so their picks stay consistent.
+    static func isUtilityExecutable(filename: String) -> Bool {
+        let lower = filename.lowercased()
+        for keyword in utilityKeywords {
+            if lower.contains(keyword) { return true }
+        }
+        return false
+    }
+
+
+    /// Reads `url` and returns the largest icon found inside, as a
+    /// `UIImage`. Returns nil when the file isn't a recognisable
+    /// PE executable, has no icon resources, or fails any of the
+    /// internal bounds / signature checks. Never throws; never
+    /// crashes on malformed input.
+    static func extractIcon(fromExecutableAt url: URL) -> UIImage? {
+        guard let data = try? Data(contentsOf: url, options: .mappedIfSafe) else {
+            return nil
+        }
+        return PEImage(data: data)?.extractIcon()
+    }
+
+
+    /// Scans the root of `gameDir` for a suitable `.exe`,
+    /// extracts its icon, and writes it as a PNG sidecar
+    /// (`.empo-artwork.png`) in the same folder.
+    ///
+    /// Selection rule:
+    ///   1. `Game.exe` (case-insensitive) wins when present.
+    ///      That's the RPG Maker default and is unambiguously
+    ///      the game binary.
+    ///   2. Otherwise, the alphabetically-first `.exe` whose
+    ///      filename doesn't match a utility-keyword blocklist
+    ///      (`Patcher.exe`, `Launcher.exe`, `unins000.exe`, etc.).
+    ///
+    /// Import-table inspection isn't used as the gate because
+    /// some games (Pokemon Uranium, JoiPlay-patched builds) load
+    /// the RGSS runtime dynamically via `LoadLibrary`, which
+    /// leaves the PE import table looking indistinguishable from
+    /// a generic Win32 app.
+    ///
+    /// Returns the sidecar path on success, nil when no
+    /// qualifying executable has an embedded icon so the caller
+    /// falls back to its next artwork source (typically
+    /// `Graphics/Titles/`). Swallows errors to fit into the
+    /// caller's fall-back chain.
+    @discardableResult
+    static func writeSidecarIfPossible(in gameDir: URL) -> String? {
+        let fm = FileManager.default
+        let sidecar = gameDir.appendingPathComponent(sidecarFilename)
+        if fm.fileExists(atPath: sidecar.path) {
+            return sidecar.path
+        }
+
+        guard let items = try? fm.contentsOfDirectory(atPath: gameDir.path) else {
+            return nil
+        }
+
+        let exeItems = items.filter { $0.lowercased().hasSuffix(".exe") }
+        let ordered: [String]
+        if let canonical = exeItems.first(where: { $0.lowercased() == "game.exe" }) {
+            ordered = [canonical] + exeItems.sorted().filter { $0 != canonical }
+        } else {
+            ordered = exeItems.sorted()
+        }
+
+        for item in ordered {
+            // Skip utility binaries unless they ARE Game.exe
+            // (defensive - some oddball game names might hit a
+            // keyword; Game.exe always qualifies).
+            if item.lowercased() != "game.exe", isUtilityExecutable(filename: item) {
+                continue
+            }
+
+            let exeURL = gameDir.appendingPathComponent(item)
+            guard let data = try? Data(contentsOf: exeURL, options: .mappedIfSafe),
+                  let pe = PEImage(data: data),
+                  let image = pe.extractIcon(),
+                  let png = image.pngData() else {
+                continue
+            }
+
+            do {
+                try png.write(to: sidecar)
+                return sidecar.path
+            } catch {
+                NSLog("[ExecutableIconExtractor] Sidecar write failed: %@", "\(error)")
+                return nil
+            }
+        }
+        return nil
+    }
+}
+
+
+// MARK: - PEImage
+
+/// Minimal PE reader covering the parts we use:
+///   - section table (so RVAs can be translated to file offsets)
+///   - data directories (used for the import table)
+///   - resource tree walking (used for icon extraction)
+///
+/// Every read is bounds-checked; constructor returns nil on any
+/// malformed header so the rest of the pipeline can treat the file
+/// as "not an icon source" and move on.
+struct PEImage {
+    private let reader: ByteReader
+    private let sections: [Section]
+    /// Start offset of the 16-entry data directory inside the
+    /// optional header, kept so we can lazily fetch individual
+    /// directories (import, resource, etc.) without re-parsing
+    /// the optional header.
+    private let dataDirectoryBase: Int
+    private let dataDirectoryCount: Int
+
+
+    struct Section {
+        let virtualAddress: UInt32
+        let virtualSize: UInt32
+        let rawOffset: Int
+        let rawSize: Int
+    }
+
+
+    /// Offsets + record sizes inside the PE layout we care about.
+    /// See <https://learn.microsoft.com/en-us/windows/win32/debug/pe-format>.
+    private enum Layout {
+        static let dosPEPointer: Int = 0x3C
+        /// 'PE\0\0' + COFF header (20 bytes).
+        static let peSignatureAndCoffHeader: Int = 24
+        /// Offsets inside the COFF header.
+        /// Layout: Machine(u16), NumberOfSections(u16),
+        /// TimeDateStamp(u32), PointerToSymbolTable(u32),
+        /// NumberOfSymbols(u32), SizeOfOptionalHeader(u16),
+        /// Characteristics(u16).
+        static let coffNumberOfSectionsOffset: Int = 2
+        static let coffSizeOfOptionalHeaderOffset: Int = 16
+        /// Optional-header magic distinguishes PE32 (0x10B, 32-bit
+        /// image) from PE32+ (0x20B, 64-bit image). Layout up to
+        /// the data directories is identical other than the
+        /// 32/64-bit BaseOfCode / ImageBase fields shifting every
+        /// following offset by 16 bytes.
+        static let optionalHeaderMagic32: UInt16 = 0x10B
+        static let optionalHeaderMagic64: UInt16 = 0x20B
+        /// Offset inside the optional header where
+        /// `NumberOfRvaAndSizes` lives. Comes right before the
+        /// data directory array. PE32: 92. PE32+: 108.
+        static let optionalNumberOfRvaAndSizesOffset32: Int = 92
+        static let optionalNumberOfRvaAndSizesOffset64: Int = 108
+        /// IMAGE_DIRECTORY_ENTRY_IMPORT index.
+        static let importDirectoryIndex: Int = 1
+        /// IMAGE_SECTION_HEADER record size.
+        static let sectionHeaderSize: Int = 40
+        /// IMAGE_IMPORT_DESCRIPTOR record size.
+        static let importDescriptorSize: Int = 20
+        /// IMAGE_IMPORT_DESCRIPTOR.Name lives at offset 12.
+        static let importDescriptorNameOffset: Int = 12
+    }
+
+
+    init?(data: Data) {
+        let reader = ByteReader(data: data)
+
+        // DOS header "MZ" at offset 0.
+        guard reader.readUInt16(at: 0) == 0x5A4D else { return nil }
+        guard let peOffset = reader.readUInt32(at: Layout.dosPEPointer) else { return nil }
+        let peBase = Int(peOffset)
+
+        // PE signature: 'P','E',0,0.
+        guard reader.readUInt32(at: peBase) == 0x00004550 else { return nil }
+
+        let coffBase = peBase + 4
+        guard let numberOfSections = reader.readUInt16(at: coffBase + Layout.coffNumberOfSectionsOffset),
+              let sizeOfOptionalHeader = reader.readUInt16(at: coffBase + Layout.coffSizeOfOptionalHeaderOffset) else {
+            return nil
+        }
+
+        let optionalBase = coffBase + 20
+        guard let optionalMagic = reader.readUInt16(at: optionalBase) else { return nil }
+        let numRvaOffset: Int
+        switch optionalMagic {
+        case Layout.optionalHeaderMagic32:
+            numRvaOffset = Layout.optionalNumberOfRvaAndSizesOffset32
+        case Layout.optionalHeaderMagic64:
+            numRvaOffset = Layout.optionalNumberOfRvaAndSizesOffset64
+        default:
+            return nil
+        }
+
+        guard let numRva = reader.readUInt32(at: optionalBase + numRvaOffset) else { return nil }
+        let dataDirectoryBase = optionalBase + numRvaOffset + 4
+        self.dataDirectoryBase = dataDirectoryBase
+        self.dataDirectoryCount = Int(numRva)
+
+        let sectionTableBase = peBase + Layout.peSignatureAndCoffHeader + Int(sizeOfOptionalHeader)
+        var parsedSections: [Section] = []
+        parsedSections.reserveCapacity(Int(numberOfSections))
+        for i in 0..<Int(numberOfSections) {
+            let base = sectionTableBase + i * Layout.sectionHeaderSize
+            guard let virtualSize = reader.readUInt32(at: base + 8),
+                  let virtualAddress = reader.readUInt32(at: base + 12),
+                  let sizeOfRawData = reader.readUInt32(at: base + 16),
+                  let pointerToRawData = reader.readUInt32(at: base + 20) else {
+                return nil
+            }
+            parsedSections.append(Section(
+                virtualAddress: virtualAddress,
+                virtualSize: virtualSize,
+                rawOffset: Int(pointerToRawData),
+                rawSize: Int(sizeOfRawData)
+            ))
+        }
+        self.sections = parsedSections
+        self.reader = reader
+    }
+
+
+    /// Walks each section looking for one whose virtual range
+    /// contains `rva`, returning the file offset of that RVA.
+    /// Returns nil when no section covers it (defensive - valid
+    /// RVAs always lie in exactly one section).
+    fileprivate func rvaToFileOffset(_ rva: UInt32) -> Int? {
+        for section in sections {
+            let start = section.virtualAddress
+            // `virtualSize` can be smaller than `rawSize` when a
+            // section is padded out to file alignment; the raw
+            // bounds are the authoritative cap for "can I read
+            // bytes at this RVA" checks.
+            let size = UInt32(max(Int(section.virtualSize), section.rawSize))
+            if rva >= start && rva < start &+ size {
+                let delta = Int(rva - start)
+                return section.rawOffset + delta
+            }
+        }
+        return nil
+    }
+
+
+    // MARK: - Imports
+
+    /// Returns true when any of the executable's imported DLL
+    /// names starts with "rgss" (case-insensitive) and ends in
+    /// ".dll". That matches the real-world RPG Maker runtime
+    /// filenames (`RGSS102E.dll`, `RGSS202J.dll`, `RGSS300.dll`,
+    /// and any JoiPlay / patched variants that keep the prefix).
+    func importsRGSSRuntime() -> Bool {
+        for name in importedDLLNames() {
+            let lower = name.lowercased()
+            if lower.hasPrefix("rgss"), lower.hasSuffix(".dll") {
+                return true
+            }
+        }
+        return false
+    }
+
+
+    /// Iterates the import directory and yields each imported DLL
+    /// name as a Swift string. Returns an empty array when the
+    /// executable has no imports (rare for a real game) or the
+    /// import directory is malformed.
+    func importedDLLNames() -> [String] {
+        guard dataDirectoryCount > Layout.importDirectoryIndex else { return [] }
+
+        let dirBase = dataDirectoryBase + Layout.importDirectoryIndex * 8
+        guard let importRVA = reader.readUInt32(at: dirBase),
+              let importSize = reader.readUInt32(at: dirBase + 4),
+              importRVA != 0, importSize != 0 else {
+            return []
+        }
+        guard let tableOffset = rvaToFileOffset(importRVA) else { return []  }
+
+        var names: [String] = []
+        var cursor = tableOffset
+        let end = tableOffset + Int(importSize)
+
+        // IMAGE_IMPORT_DESCRIPTOR array terminated by a zeroed
+        // entry. We read the Name RVA, resolve it to a file
+        // offset, then read a null-terminated ASCII string.
+        while cursor + Layout.importDescriptorSize <= end {
+            guard let nameRVA = reader.readUInt32(at: cursor + Layout.importDescriptorNameOffset) else {
+                break
+            }
+            if nameRVA == 0 { break } // terminator
+            if let fileOffset = rvaToFileOffset(nameRVA),
+               let name = reader.readNullTerminatedASCII(at: fileOffset) {
+                names.append(name)
+            }
+            cursor += Layout.importDescriptorSize
+        }
+        return names
+    }
+
+
+    // MARK: - Icons
+
+    /// Windows resource type constants we consume.
+    /// <https://learn.microsoft.com/en-us/windows/win32/menurc/resource-types>
+    private enum ResourceType: UInt32 {
+        case icon = 3
+        case groupIcon = 14
+    }
+
+
+    /// Internal layout offsets inside IMAGE_RESOURCE_DIRECTORY
+    /// and IMAGE_RESOURCE_DIRECTORY_ENTRY.
+    private enum ResourceLayout {
+        static let directoryHeaderSize: Int = 16
+        static let namedEntryCountOffset: Int = 12
+        static let idEntryCountOffset: Int = 14
+        static let directoryEntrySize: Int = 8
+    }
+
+
+    func extractIcon() -> UIImage? {
+        guard let resourceSection = resourceSectionEntry() else { return nil }
+        let sectionStart = resourceSection.rawOffset
+        let sectionVA = resourceSection.virtualAddress
+
+        var icons: [UInt32: (data: Data, size: Int)] = [:]
+        var groups: [ParsedGroup] = []
+        walkResourceDirectory(
+            sectionStart: sectionStart,
+            sectionVirtualAddress: sectionVA,
+            directoryOffset: sectionStart,
+            level: 0,
+            currentType: nil,
+            currentName: nil,
+            icons: &icons,
+            groups: &groups
+        )
+
+        // Pick the largest icon variant we can actually emit. A
+        // variant is only usable when its matching RT_ICON
+        // payload is present in the icons dict - some PEs
+        // reference variants in GROUP_ICON that the ID subtree
+        // never delivers.
+        var bestEntry: GroupIconEntry?
+        for group in groups {
+            for entry in group.entries {
+                if icons[entry.iconID] == nil { continue }
+                if let current = bestEntry {
+                    if entry.effectiveArea > current.effectiveArea {
+                        bestEntry = entry
+                    }
+                } else {
+                    bestEntry = entry
+                }
+            }
+        }
+        guard let best = bestEntry, icons[best.iconID] != nil else { return nil }
+
+        // Payload can be a raw DIB (BITMAPINFOHEADER + pixel data
+        // + optional mask) or a PNG starting with the PNG
+        // signature (Vista+ uses this for 256x256 entries). The
+        // .ico container works for both.
+        let icoBlob = buildICO(entries: [best], icons: icons)
+        return UIImage(data: icoBlob)
+    }
+
+
+    /// Finds the named `.rsrc` section by parsing section names
+    /// (rather than reading the resource entry in the data
+    /// directory) since some PEs list `.rsrc` under a different
+    /// directory order. Returns the section metadata so the
+    /// resource walker can translate RVAs to file offsets.
+    private func resourceSectionEntry() -> Section? {
+        let reader = self.reader
+        guard let peOffset = reader.readUInt32(at: Layout.dosPEPointer) else { return nil }
+        let peBase = Int(peOffset)
+        let coffBase = peBase + 4
+        guard let numberOfSections = reader.readUInt16(at: coffBase + Layout.coffNumberOfSectionsOffset),
+              let sizeOfOptionalHeader = reader.readUInt16(at: coffBase + Layout.coffSizeOfOptionalHeaderOffset) else {
+            return nil
+        }
+        let sectionTableBase = peBase + Layout.peSignatureAndCoffHeader + Int(sizeOfOptionalHeader)
+        for i in 0..<Int(numberOfSections) {
+            let base = sectionTableBase + i * Layout.sectionHeaderSize
+            guard let nameBytes = reader.readBytes(at: base, length: 8) else { continue }
+            let name = String(bytes: nameBytes, encoding: .ascii)?
+                .trimmingCharacters(in: CharacterSet(charactersIn: "\0")) ?? ""
+            if name == ".rsrc" {
+                return sections[i]
+            }
+        }
+        return nil
+    }
+
+
+    private func walkResourceDirectory(
+        sectionStart: Int,
+        sectionVirtualAddress: UInt32,
+        directoryOffset: Int,
+        level: Int,
+        currentType: UInt32?,
+        currentName: UInt32?,
+        icons: inout [UInt32: (data: Data, size: Int)],
+        groups: inout [ParsedGroup]
+    ) {
+        guard let namedCount = reader.readUInt16(at: directoryOffset + ResourceLayout.namedEntryCountOffset),
+              let idCount = reader.readUInt16(at: directoryOffset + ResourceLayout.idEntryCountOffset) else {
+            return
+        }
+        let totalEntries = Int(namedCount) + Int(idCount)
+        let entriesBase = directoryOffset + ResourceLayout.directoryHeaderSize
+
+        for i in 0..<totalEntries {
+            let entryOffset = entriesBase + i * ResourceLayout.directoryEntrySize
+            guard let nameOrId = reader.readUInt32(at: entryOffset),
+                  let offsetToData = reader.readUInt32(at: entryOffset + 4) else {
+                continue
+            }
+
+            // Level-0 entries are resource types. Skip everything
+            // that isn't an icon type so we don't recurse into
+            // version info / strings / manifests.
+            if level == 0 {
+                if nameOrId & 0x80000000 != 0 { continue }
+                guard nameOrId == ResourceType.icon.rawValue || nameOrId == ResourceType.groupIcon.rawValue else {
+                    continue
+                }
+            }
+
+            let isDirectory = (offsetToData & 0x80000000) != 0
+            let subOffset = Int(offsetToData & 0x7FFFFFFF)
+
+            if isDirectory {
+                let nextType = (level == 0) ? nameOrId : currentType
+                let nextName = (level == 1) ? nameOrId : currentName
+                walkResourceDirectory(
+                    sectionStart: sectionStart,
+                    sectionVirtualAddress: sectionVirtualAddress,
+                    directoryOffset: sectionStart + subOffset,
+                    level: level + 1,
+                    currentType: nextType,
+                    currentName: nextName,
+                    icons: &icons,
+                    groups: &groups
+                )
+            } else {
+                guard let type = currentType,
+                      let resourceName = currentName else {
+                    continue
+                }
+                processDataEntry(
+                    dataEntryOffset: sectionStart + subOffset,
+                    sectionStart: sectionStart,
+                    sectionVirtualAddress: sectionVirtualAddress,
+                    type: type,
+                    resourceName: resourceName,
+                    icons: &icons,
+                    groups: &groups
+                )
+            }
+        }
+    }
+
+
+    private func processDataEntry(
+        dataEntryOffset: Int,
+        sectionStart: Int,
+        sectionVirtualAddress: UInt32,
+        type: UInt32,
+        resourceName: UInt32,
+        icons: inout [UInt32: (data: Data, size: Int)],
+        groups: inout [ParsedGroup]
+    ) {
+        guard let payloadRVA = reader.readUInt32(at: dataEntryOffset),
+              let payloadSize = reader.readUInt32(at: dataEntryOffset + 4) else {
+            return
+        }
+        let payloadOffset = sectionStart + Int(payloadRVA) - Int(sectionVirtualAddress)
+        guard let payload = reader.readBytes(at: payloadOffset, length: Int(payloadSize)) else {
+            return
+        }
+        switch type {
+        case ResourceType.icon.rawValue:
+            icons[resourceName] = (Data(payload), Int(payloadSize))
+        case ResourceType.groupIcon.rawValue:
+            if let parsed = parseGroupIcon(Data(payload)) {
+                groups.append(parsed)
+            }
+        default:
+            break
+        }
+    }
+
+
+    // MARK: - GROUP_ICON parsing + ICO reassembly
+
+    private struct ParsedGroup {
+        let entries: [GroupIconEntry]
+    }
+
+
+    private struct GroupIconEntry {
+        let rawWidth: UInt8
+        let rawHeight: UInt8
+        let colorCount: UInt8
+        let planes: UInt16
+        let bitCount: UInt16
+        let bytesInRes: UInt32
+        let iconID: UInt32
+
+        /// Effective pixel area with the 0==256 promotion applied
+        /// so true-colour 256x256 icons (width/height stored as 0)
+        /// beat smaller variants in the "bigger is better"
+        /// comparison.
+        var effectiveArea: Int {
+            let w = rawWidth == 0 ? 256 : Int(rawWidth)
+            let h = rawHeight == 0 ? 256 : Int(rawHeight)
+            return w * h
+        }
+    }
+
+
+    private func parseGroupIcon(_ data: Data) -> ParsedGroup? {
+        guard data.count >= 6 else { return nil }
+        let reader = ByteReader(data: data)
+        guard reader.readUInt16(at: 2) == 1 else { return nil }
+        guard let count = reader.readUInt16(at: 4) else { return nil }
+
+        var entries: [GroupIconEntry] = []
+        entries.reserveCapacity(Int(count))
+
+        for i in 0..<Int(count) {
+            let base = 6 + i * 14
+            guard let rawWidth = reader.readUInt8(at: base),
+                  let rawHeight = reader.readUInt8(at: base + 1),
+                  let colorCount = reader.readUInt8(at: base + 2),
+                  let planes = reader.readUInt16(at: base + 4),
+                  let bitCount = reader.readUInt16(at: base + 6),
+                  let bytesInRes = reader.readUInt32(at: base + 8),
+                  let iconID = reader.readUInt16(at: base + 12) else {
+                return nil
+            }
+            entries.append(GroupIconEntry(
+                rawWidth: rawWidth,
+                rawHeight: rawHeight,
+                colorCount: colorCount,
+                planes: planes,
+                bitCount: bitCount,
+                bytesInRes: bytesInRes,
+                iconID: UInt32(iconID)
+            ))
+        }
+        return ParsedGroup(entries: entries)
+    }
+
+
+    private func buildICO(
+        entries: [GroupIconEntry],
+        icons: [UInt32: (data: Data, size: Int)]
+    ) -> Data {
+        var output = Data()
+        // ICONDIR: reserved (u16=0), type (u16=1 icon), count.
+        output.appendLE(UInt16(0))
+        output.appendLE(UInt16(1))
+        output.appendLE(UInt16(entries.count))
+
+        var runningOffset = 6 + 16 * entries.count
+        for entry in entries {
+            guard let icon = icons[entry.iconID] else { continue }
+            output.append(entry.rawWidth)
+            output.append(entry.rawHeight)
+            output.append(entry.colorCount)
+            output.append(0)
+            output.appendLE(entry.planes)
+            output.appendLE(entry.bitCount)
+            output.appendLE(UInt32(icon.size))
+            output.appendLE(UInt32(runningOffset))
+            runningOffset += icon.size
+        }
+
+        for entry in entries {
+            if let icon = icons[entry.iconID] {
+                output.append(icon.data)
+            }
+        }
+        return output
+    }
+}
+
+
+// MARK: - ByteReader
+
+/// Bounds-checked reader over an arbitrary `Data` buffer. Every
+/// read returns an optional so one malformed PE doesn't surface
+/// as a crash; callers translate failures into the same nil result
+/// as "no icon found".
+private struct ByteReader {
+    let data: Data
+
+    func readUInt8(at offset: Int) -> UInt8? {
+        guard offset >= 0, offset + 1 <= data.count else { return nil }
+        return data[data.startIndex + offset]
+    }
+
+    func readUInt16(at offset: Int) -> UInt16? {
+        guard offset >= 0, offset + 2 <= data.count else { return nil }
+        let lo = UInt16(data[data.startIndex + offset])
+        let hi = UInt16(data[data.startIndex + offset + 1])
+        return lo | (hi << 8)
+    }
+
+    func readUInt32(at offset: Int) -> UInt32? {
+        guard offset >= 0, offset + 4 <= data.count else { return nil }
+        var result: UInt32 = 0
+        for i in 0..<4 {
+            result |= UInt32(data[data.startIndex + offset + i]) << (8 * i)
+        }
+        return result
+    }
+
+    func readBytes(at offset: Int, length: Int) -> Data.SubSequence? {
+        guard offset >= 0, length >= 0 else { return nil }
+        let end = offset + length
+        guard end <= data.count else { return nil }
+        return data[(data.startIndex + offset)..<(data.startIndex + end)]
+    }
+
+    /// Reads a null-terminated ASCII string starting at `offset`,
+    /// capped at a reasonable length so a malformed PE without a
+    /// terminator doesn't scan to EOF. DLL names in PE imports
+    /// comfortably fit in 256 chars (MS_MAX_PATH territory).
+    func readNullTerminatedASCII(at offset: Int, maxLength: Int = 256) -> String? {
+        guard offset >= 0 else { return nil }
+        var bytes: [UInt8] = []
+        bytes.reserveCapacity(min(maxLength, 64))
+        for i in 0..<maxLength {
+            let pos = offset + i
+            guard pos < data.count else { break }
+            let byte = data[data.startIndex + pos]
+            if byte == 0 { break }
+            bytes.append(byte)
+        }
+        return bytes.isEmpty ? nil : String(bytes: bytes, encoding: .ascii)
+    }
+}
+
+
+private extension Data {
+    /// Little-endian append for the two primitive integer widths
+    /// used in the ICO format. PE is always little-endian on
+    /// x86/x64, and .ico matches.
+    mutating func appendLE(_ value: UInt16) {
+        append(UInt8(value & 0xFF))
+        append(UInt8((value >> 8) & 0xFF))
+    }
+
+    mutating func appendLE(_ value: UInt32) {
+        append(UInt8(value & 0xFF))
+        append(UInt8((value >> 8) & 0xFF))
+        append(UInt8((value >> 16) & 0xFF))
+        append(UInt8((value >> 24) & 0xFF))
+    }
+}

--- a/ios/Empo/src/Library/GameArtworkView.swift
+++ b/ios/Empo/src/Library/GameArtworkView.swift
@@ -46,44 +46,103 @@ struct GameArtworkView: View {
     @ViewBuilder
     private var content: some View {
         if let path = artworkPath, let uiImage = ImageCache.shared.image(for: path) {
-            let image = Image(uiImage: uiImage)
+            sized(loadedArtwork(path: path, uiImage: uiImage))
+        } else {
+            sized(placeholderContent)
+        }
+    }
+
+    @ViewBuilder
+    private func sized<V: View>(_ view: V) -> some View {
+        if let size {
+            view
+                .frame(width: size, height: size)
+                .clipShape(.rect(cornerRadius: cornerRadius))
+        } else {
+            view
+        }
+    }
+
+    /// Renders the image loaded from disk. PE-extracted icons
+    /// (our sidecar files) typically ship with transparent
+    /// backgrounds; stretching them to `.fill` would let the
+    /// transparency reveal whatever surface sits behind the card,
+    /// which looks wrong when the artwork is meant to be the
+    /// card's focal point. Route those through the composite
+    /// branch so the icon floats on the same gradient the
+    /// empty-state placeholder uses.
+    @ViewBuilder
+    private func loadedArtwork(path: String, uiImage: UIImage) -> some View {
+        if isExecutableIconSidecar(path: path) {
+            iconComposite(uiImage: uiImage)
+        } else {
+            Image(uiImage: uiImage)
                 .resizable()
                 .aspectRatio(contentMode: .fill)
-            if let size {
-                image
-                    .frame(width: size, height: size)
-                    .clipShape(.rect(cornerRadius: cornerRadius))
-            } else {
-                image
-            }
-        } else {
-            // Base uses secondarySystemBackground so light mode lands on
-            // a soft gray instead of pure white (which reads cheap when
-            // it sits right next to vibrant artwork on the other cards).
-            // A subtle top-to-bottom highlight gradient adds depth so
-            // the placeholder feels crafted rather than flat.
-            let placeholder = ZStack {
-                Color(.secondarySystemBackground)
-                LinearGradient(
-                    stops: [
-                        .init(color: .white.opacity(0.10), location: 0),
-                        .init(color: .clear, location: 0.5),
-                        .init(color: .black.opacity(0.05), location: 1),
-                    ],
-                    startPoint: .top,
-                    endPoint: .bottom
-                )
-                Image(systemName: placeholderIcon)
-                    .font(.system(size: placeholderIconSize))
-                    .foregroundStyle(.quaternary)
-            }
-            if let size {
-                placeholder
-                    .frame(width: size, height: size)
-                    .clipShape(.rect(cornerRadius: cornerRadius))
-            } else {
-                placeholder
+        }
+    }
+
+    @ViewBuilder
+    private var placeholderContent: some View {
+        ZStack {
+            placeholderBackground
+            Image(systemName: placeholderIcon)
+                .font(.system(size: placeholderIconSize))
+                .foregroundStyle(.quaternary)
+        }
+    }
+
+    /// Shared backdrop for the empty placeholder and the
+    /// icon-composite path. Base uses secondarySystemBackground
+    /// so light mode lands on a soft gray instead of pure white
+    /// (which reads cheap next to vibrant artwork on sibling
+    /// cards). A subtle top-to-bottom highlight gradient adds
+    /// depth so the surface feels crafted rather than flat.
+    @ViewBuilder
+    private var placeholderBackground: some View {
+        ZStack {
+            Color(.secondarySystemBackground)
+            LinearGradient(
+                stops: [
+                    .init(color: .white.opacity(0.10), location: 0),
+                    .init(color: .clear, location: 0.5),
+                    .init(color: .black.opacity(0.05), location: 1),
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        }
+    }
+
+    /// Renders a transparent icon artwork centered on the
+    /// placeholder gradient. The icon keeps its aspect ratio and
+    /// takes up a fraction of the frame so padding shows around
+    /// it - PE icons are typically 128-256px whereas the card
+    /// itself can be substantially larger, so stretching would
+    /// blur them. Inset scales to the container so the icon
+    /// reads at the same relative size in the 48pt list row and
+    /// the 150pt+ grid card.
+    @ViewBuilder
+    private func iconComposite(uiImage: UIImage) -> some View {
+        ZStack {
+            placeholderBackground
+            GeometryReader { geo in
+                let side = min(geo.size.width, geo.size.height)
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .interpolation(.high)
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: side * 0.75, height: side * 0.75)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
+    }
+
+    /// Artwork stored at the sidecar path is always a PE icon
+    /// we extracted from `Game.exe`. Using the filename as the
+    /// signal avoids per-pixel alpha scans and stays consistent
+    /// with the side that wrote the file.
+    private func isExecutableIconSidecar(path: String) -> Bool {
+        (path as NSString).lastPathComponent == ExecutableIconExtractor.sidecarFilename
     }
 }

--- a/ios/Empo/src/Library/GameLibrary.swift
+++ b/ios/Empo/src/Library/GameLibrary.swift
@@ -425,15 +425,30 @@ class GameLibrary {
         try fm.createDirectory(at: tmpDir, withIntermediateDirectories: true)
         defer { try? fm.removeItem(at: tmpDir) }
 
-        // Mid-extract artwork surfacing. `findArtwork` picks the
-        // alphabetically-smallest image under `Graphics/Titles/`,
-        // so we mirror that rule here by keeping the smallest
-        // filename we've seen and updating the card every time a
-        // smaller one comes through. This guarantees the card's
-        // artwork matches what the post-reload card will show
-        // (otherwise the card would swap to a different image
-        // once the import finished, which looks like a flicker).
-        let bestArtworkFilename = Mutex<String?>(nil)
+        // Mid-extract artwork surfacing. Two sources are mirrored
+        // against the post-reload `findArtwork` rule:
+        //   1. The `.exe` icon (preferred). Only executables that
+        //      import `rgss*.dll` qualify - patchers, updaters,
+        //      and installer binaries sitting next to the game
+        //      (e.g. Pokemon Uranium's `Patcher.exe`) get skipped
+        //      wholesale. `Game.exe` is the canonical RPG Maker
+        //      binary and wins outright when present; other
+        //      qualifying `.exe`s set a tentative sidecar that
+        //      `Game.exe` can still overwrite if it arrives
+        //      later in archive order.
+        //   2. Alphabetically-smallest `Graphics/Titles/*` image
+        //      (fallback). Only used when no qualifying
+        //      executable has landed yet - once one does,
+        //      subsequent Titles updates are ignored because the
+        //      card would flicker when post-reload `findArtwork`
+        //      picks the exe sidecar over the title image.
+        //
+        // Both hooks rebuild the committed `GameEntry` through
+        // `updateCardArtwork`, so the card cross-fades as the
+        // better source lands.
+        let exeArtworkLocked = Mutex(false)
+        let hasTentativeExeArtwork = Mutex(false)
+        let bestTitlesFilename = Mutex<String?>(nil)
         do {
             try ArchiveExtractor.extract(
                 archive: sourceURL,
@@ -443,16 +458,76 @@ class GameLibrary {
                     self.updateCardProgress(importID, pct)
                 },
                 onFileWritten: { relative, diskURL in
-                    // Accept any image under a `Graphics/Titles/`
-                    // folder regardless of depth (handles flat and
-                    // single-wrapper archives alike).
                     let lower = relative.lowercased()
+                    let filename = (relative as NSString).lastPathComponent
+
+                    // `.exe` branch - only consider root-level
+                    // executables (depth 0 or 1, matching the
+                    // archive's optional wrapper folder).
+                    if lower.hasSuffix(".exe") {
+                        let components = lower.split(separator: "/", omittingEmptySubsequences: false)
+                        let depth = components.count - 1
+                        guard depth <= 1 else { return }
+                        if exeArtworkLocked.withLock({ $0 }) { return }
+
+                        let isGameExe = filename.lowercased() == "game.exe"
+                        // Skip utility binaries (patchers,
+                        // updaters, launchers, etc.) outright.
+                        // `Game.exe` bypasses this check because
+                        // it's the canonical RPG Maker default.
+                        if !isGameExe, ExecutableIconExtractor.isUtilityExecutable(filename: filename) {
+                            return
+                        }
+                        // Non-canonical binaries defer to any
+                        // previously-written tentative sidecar:
+                        // only `Game.exe` can still overwrite
+                        // because it's the rule winner at
+                        // post-reload scan time. Accepting a
+                        // second non-`Game.exe` here would cause
+                        // a flicker when the library rescan
+                        // later picks a different one.
+                        if !isGameExe, hasTentativeExeArtwork.withLock({ $0 }) { return }
+
+                        guard let data = try? Data(contentsOf: diskURL, options: .mappedIfSafe) else {
+                            return
+                        }
+                        guard let pe = PEImage(data: data),
+                              let image = pe.extractIcon(),
+                              let png = image.pngData() else {
+                            return
+                        }
+
+                        let parent = diskURL.deletingLastPathComponent()
+                        let sidecarURL = parent.appendingPathComponent(ExecutableIconExtractor.sidecarFilename)
+                        do {
+                            try png.write(to: sidecarURL)
+                        } catch {
+                            NSLog("[GameLibrary] Sidecar write failed: %@", "\(error)")
+                            return
+                        }
+                        ImageCache.shared.evict(path: sidecarURL.path)
+                        _ = ImageCache.shared.image(for: sidecarURL.path)
+
+                        hasTentativeExeArtwork.withLock { $0 = true }
+                        if isGameExe {
+                            // Canonical binary - no further .exe
+                            // needs to be inspected.
+                            exeArtworkLocked.withLock { $0 = true }
+                        }
+                        self.updateCardArtwork(importID, artworkPath: sidecarURL.path)
+                        return
+                    }
+
+                    // Titles fallback - skip once an RGSS exe
+                    // icon has landed (the card would flicker
+                    // when post-reload findArtwork picks the exe
+                    // sidecar over the title image).
+                    guard !hasTentativeExeArtwork.withLock({ $0 }) else { return }
                     guard lower.contains("graphics/titles/") else { return }
                     let ext = (relative as NSString).pathExtension.lowercased()
                     guard ["png", "jpg", "jpeg", "bmp"].contains(ext) else { return }
 
-                    let filename = (relative as NSString).lastPathComponent
-                    let shouldUpdate = bestArtworkFilename.withLock { best -> Bool in
+                    let shouldUpdate = bestTitlesFilename.withLock { best -> Bool in
                         if let current = best, current <= filename { return false }
                         best = filename
                         return true
@@ -536,8 +611,23 @@ class GameLibrary {
 
 
     nonisolated private static func findArtwork(at url: URL) -> String? {
-        let titlesDir = url.appendingPathComponent("Graphics/Titles")
         let fm = FileManager.default
+
+        // Prefer the pre-extracted `.exe` icon when available. The
+        // sidecar is written once at import time (or lazily
+        // on-demand below) and carries the "official" game icon
+        // the developer shipped inside the executable. Only fall
+        // through to `Graphics/Titles/` when we couldn't produce
+        // an icon from the `.exe` (or no `.exe` exists).
+        let sidecar = url.appendingPathComponent(ExecutableIconExtractor.sidecarFilename)
+        if fm.fileExists(atPath: sidecar.path) {
+            return sidecar.path
+        }
+        if let sidecarPath = ExecutableIconExtractor.writeSidecarIfPossible(in: url) {
+            return sidecarPath
+        }
+
+        let titlesDir = url.appendingPathComponent("Graphics/Titles")
         guard let items = try? fm.contentsOfDirectory(atPath: titlesDir.path) else { return nil }
 
         let imageExtensions: Set<String> = ["png", "jpg", "jpeg", "bmp"]


### PR DESCRIPTION
## Summary

Makes the imported game's artwork come from the developer-authored `.exe` icon instead of the first image under `Graphics/Titles/`. The PE-embedded icon is closer to "official art" than a random title-screen still.

## Parser

New `ExecutableIconExtractor` + `PEImage` types. Minimal PE reader covering just what's needed: DOS + PE headers, section table walk, import-table parse, resource tree walk for `RT_GROUP_ICON` + `RT_ICON`, and ICO reassembly to feed `UIImage(data:)`. Bounds-checked throughout - malformed input returns nil rather than crashing.

Supports both PE32 (32-bit) and PE32+ (64-bit) images.

## Executable selection

1. `Game.exe` wins outright when present - RPG Maker default.
2. Otherwise alphabetically-first `.exe` whose filename doesn't match a utility-keyword blocklist (`patcher`, `updater`, `installer`, `unins`, `config`, `setup`, `editor`, `rtp`, `dxwebsetup`, `vcredist`).

Tried the RGSS-import-table gate first but Pokemon Uranium and JoiPlay-patched builds load the runtime dynamically via `LoadLibrary`, so static imports don't distinguish them from generic Win32 binaries. Name-based blocklist is simpler and covers the common cases.

## Sidecar file

The extracted icon is written once to `<gameFolder>/.empo-artwork.png` so library scans don't re-parse the `.exe` on every reload. The sidecar travels with the game folder through import / delete.

## Integration

- `GameLibrary.findArtwork` checks the sidecar first, creates one on demand, and only falls back to `Graphics/Titles/*` when no qualifying `.exe` produces an icon.
- `GameLibrary.importArchive` mid-extract hook watches for root-level `.exe`s, extracts the icon in-place, and writes the sidecar before the extract completes so the card shows real artwork as soon as the main executable is written. `Game.exe` overrides any tentative sidecar written by an earlier qualifying candidate.
- `GameArtworkView` detects sidecar paths and renders them centered on the same gradient backdrop used by the empty placeholder. PE icons ship with transparent backgrounds and stretching them to `.fill` would let the transparency leak through; the composite branch keeps aspect ratio and adds padding so the icon sits at 75% of the container.

## Testing

- Simulator build: passes
- Device build: passes
- Verified on device with Pokemon Uranium (`Uranium.exe` + `Patcher.exe` + `Game.exe`), Pokemon Z, BTTheManor.