### PR TITLE
feat: replace image-source action sheet with content-sized bottom sheet

### DIFF
--- a/ios/Empo/src/Library/GameInfoView.swift
+++ b/ios/Empo/src/Library/GameInfoView.swift
@@ -191,14 +191,14 @@ struct GameInfoView: View {
             }
             .imageSourcePicker(
                 isPresented: $showArtworkPicker,
-                title: "Game artwork",
+                title: "Artwork",
                 hasExisting: hasCustomArtwork,
                 onImageSelected: { saveArtwork($0) },
                 onRemove: { removeArtwork() }
             )
             .imageSourcePicker(
                 isPresented: $showBannerPicker,
-                title: "Game banner",
+                title: "Banner",
                 hasExisting: hasCustomBanner,
                 onImageSelected: { saveBanner($0) },
                 onRemove: { removeBanner() }

--- a/ios/Empo/src/Library/ImageSourcePicker.swift
+++ b/ios/Empo/src/Library/ImageSourcePicker.swift
@@ -16,18 +16,16 @@ struct ImageSourcePickerModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .confirmationDialog(title, isPresented: $isPresented, titleVisibility: .visible) {
-                Button("Camera Roll") { showPhotoPicker = true }
-
-                if UIImagePickerController.isSourceTypeAvailable(.camera) {
-                    Button("Take Photo") { showCamera = true }
-                }
-
-                Button("Choose File") { showDocumentPicker = true }
-
-                if hasExisting, let onRemove {
-                    Button("Remove", role: .destructive) { onRemove() }
-                }
+            .sheet(isPresented: $isPresented) {
+                ImageSourceSheet(
+                    isPresented: $isPresented,
+                    title: title,
+                    hasExisting: hasExisting,
+                    onPickPhoto: { showPhotoPicker = true },
+                    onTakePhoto: { showCamera = true },
+                    onPickFile: { showDocumentPicker = true },
+                    onRemove: onRemove
+                )
             }
             .sheet(isPresented: $showPhotoPicker) {
                 PhotoLibraryPicker(onImageSelected: onImageSelected)

--- a/ios/Empo/src/Library/ImageSourceSheet.swift
+++ b/ios/Empo/src/Library/ImageSourceSheet.swift
@@ -1,0 +1,155 @@
+import SwiftUI
+
+
+/// Modal sheet offering the three image-source options (Photos /
+/// Camera / Files) plus an optional "Remove" action when the
+/// caller already has an image set. Replaces the previous
+/// `confirmationDialog` action-sheet so the UI matches the rest
+/// of the app's bottom-sheet patterns (library sort, experimental
+/// info) instead of surfacing a system dialog that looks out of
+/// place next to native-SwiftUI sheets.
+struct ImageSourceSheet: View {
+    @Binding var isPresented: Bool
+    let title: String
+    let hasExisting: Bool
+    let onPickPhoto: () -> Void
+    let onTakePhoto: () -> Void
+    let onPickFile: () -> Void
+    let onRemove: (() -> Void)?
+
+    /// Content height reported via `.onGeometryChange`. Zero
+    /// before first layout, at which point the detent falls
+    /// back to `.medium` so the sheet never flashes collapsed.
+    /// Same pattern as `ExperimentalInfoSheet` and
+    /// `ExperimentalConfirmSheet`.
+    @State private var measuredHeight: CGFloat = 0
+    /// Accounting for the nav bar + drag indicator above the
+    /// measured content. Matches the value used by the other
+    /// auto-sizing sheets so all of them settle at consistent
+    /// visible heights.
+    private let chromeAllowance: CGFloat = 64
+
+    /// Hide the "Take Photo" row when the device can't actually
+    /// launch the camera (iPad without a rear camera, Simulator).
+    private var cameraAvailable: Bool {
+        UIImagePickerController.isSourceTypeAvailable(.camera)
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: Spacing.lg) {
+                // Sources group - rounded card that mirrors the
+                // native grouped-list look without embedding in a
+                // List (which would want to fill the sheet).
+                VStack(spacing: 0) {
+                    ImageSourceRow(
+                        icon: "photo.on.rectangle",
+                        label: "Camera Roll"
+                    ) {
+                        isPresented = false
+                        onPickPhoto()
+                    }
+
+                    if cameraAvailable {
+                        rowSeparator
+                        ImageSourceRow(
+                            icon: "camera",
+                            label: "Take Photo"
+                        ) {
+                            isPresented = false
+                            onTakePhoto()
+                        }
+                    }
+
+                    rowSeparator
+                    ImageSourceRow(
+                        icon: "folder",
+                        label: "Choose File"
+                    ) {
+                        isPresented = false
+                        onPickFile()
+                    }
+                }
+                .background(Color(.secondarySystemGroupedBackground))
+                .clipShape(.rect(cornerRadius: Radius.md))
+
+                if hasExisting, let onRemove {
+                    // Destructive "Remove" action as its own card
+                    // so it reads as separate from the sources,
+                    // matching the sectioning pattern users expect
+                    // from grouped lists.
+                    ImageSourceRow(
+                        icon: "trash",
+                        label: "Remove",
+                        role: .destructive
+                    ) {
+                        isPresented = false
+                        onRemove()
+                    }
+                    .background(Color(.secondarySystemGroupedBackground))
+                    .clipShape(.rect(cornerRadius: Radius.md))
+                }
+            }
+            .padding(.horizontal, Spacing.xl)
+            .padding(.vertical, Spacing.xl)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .top)
+            .onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.size.height
+            } action: { newHeight in
+                measuredHeight = newHeight
+            }
+            .background(Color(.systemGroupedBackground))
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Cancel") { isPresented = false }
+                }
+            }
+        }
+        .presentationDetents(
+            measuredHeight > 0
+                ? [.height(measuredHeight + chromeAllowance)]
+                : [.medium]
+        )
+        .presentationDragIndicator(.visible)
+        .tint(.brand)
+    }
+
+    /// Hairline separator between rows inside the sources card.
+    /// Indented past the icon column so it only spans the text
+    /// area, matching the visual rhythm of UIKit grouped lists.
+    private var rowSeparator: some View {
+        Divider()
+            .padding(.leading, Spacing.lg + 24 + Spacing.lg)
+    }
+}
+
+
+/// Single tappable row inside `ImageSourceSheet`. Kept private to
+/// the file because the layout (SF Symbol + label + chevron) is
+/// specific to this sheet - the library sort rows use a different
+/// right-edge accessory (a checkmark).
+private struct ImageSourceRow: View {
+    let icon: String
+    let label: String
+    var role: ButtonRole? = nil
+    let action: () -> Void
+
+    var body: some View {
+        Button(role: role, action: action) {
+            HStack(spacing: Spacing.lg) {
+                Image(systemName: icon)
+                    .foregroundStyle(role == .destructive ? .red : .secondary)
+                    .frame(width: 24)
+                Text(label)
+                    .foregroundStyle(role == .destructive ? .red : .primary)
+                Spacer()
+            }
+            .padding(.horizontal, Spacing.lg)
+            .padding(.vertical, Spacing.lg)
+            .contentShape(Rectangle())
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the native `confirmationDialog` that appeared when tapping the artwork or banner in Game Info with a proper bottom sheet that matches the rest of the app's sheet patterns.

## Changes

- New `ImageSourceSheet` with a centered title, sources grouped in a rounded card (Camera Roll, Take Photo, Choose File), and a separate destructive "Remove" card when the game already has a custom image.
- Sheet auto-sizes to content via `onGeometryChange` + `chromeAllowance`, mirroring the pattern used by `ExperimentalInfoSheet` and `ExperimentalConfirmSheet`. Shorter when camera is unavailable or no existing image exists, taller when both rows are present.
- Titles shortened: "Game artwork" -> "Artwork", "Game banner" -> "Banner".
- `ImageSourcePickerModifier` now presents `ImageSourceSheet` instead of `confirmationDialog`; the photo / camera / document pickers it routes to are unchanged.

## Testing

- Simulator build: passes
- Device build: passes
- Verified on both targets across the four visible-row combinations (with/without existing image, camera available/unavailable).