### PR TITLE
refactor: fill accessibility gaps and align debug overlay with theme tokens

### DIFF
--- a/ios/Empo/src/Design/Theme.swift
+++ b/ios/Empo/src/Design/Theme.swift
@@ -141,11 +141,17 @@ enum AppFont {
     /// A small bold button label (used by inline CTAs and chips).
     static let buttonSmall = Font.footnote.weight(.semibold)
 
-    /// Fixed-width monospaced body for the debug overlay.
-    static let debugBody = Font.footnote.monospaced()
+    /// Monospaced body row used by each line of the debug overlay.
+    static let debugBody = Font.system(size: 13, weight: .medium, design: .monospaced)
 
-    /// Bold monospaced title for the debug overlay.
-    static let debugTitle = Font.body.bold().monospaced()
+    /// Bold monospaced title for the game name + RGSS version line
+    /// at the top of the debug overlay.
+    static let debugTitle = Font.system(size: 14, weight: .bold, design: .monospaced)
+
+    /// Bold monospaced FPS readout (slightly larger than the body
+    /// rows so the current frame rate is the first thing the eye
+    /// lands on when the overlay is visible).
+    static let debugFPS = Font.system(size: 17, weight: .bold, design: .monospaced)
 }
 
 //

--- a/ios/Empo/src/Library/GameHeroCard.swift
+++ b/ios/Empo/src/Library/GameHeroCard.swift
@@ -83,6 +83,12 @@ struct GameHeroCard: View {
                         .foregroundStyle(.white)
                         .iconShadow()
                         .padding(Spacing.xl)
+                        // Icon is decorative - the whole card is
+                        // already a tappable "resume game" target
+                        // announced by the enclosing Button, so
+                        // reading the glyph separately would just
+                        // repeat context for VoiceOver users.
+                        .accessibilityHidden(true)
                 }
                 .clipShape(.rect(cornerRadius: Radius.lg))
                 .cardShadow()

--- a/ios/Empo/src/Library/GameInfoView.swift
+++ b/ios/Empo/src/Library/GameInfoView.swift
@@ -176,13 +176,11 @@ struct GameInfoView: View {
                     }
                     .frame(maxWidth: 250)
                     .animation(Motion.standard, value: titleScrollProgress)
-                    .background(
-                        GeometryReader { geo in
-                            Color.clear.onAppear {
-                                navBarBottomY = geo.frame(in: .global).maxY
-                            }
-                        }
-                    )
+                    .onGeometryChange(for: CGFloat.self) { proxy in
+                        proxy.frame(in: .global).maxY
+                    } action: { newValue in
+                        navBarBottomY = newValue
+                    }
                 }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Close") { dismiss() }

--- a/ios/Empo/src/Library/GameLibraryView.swift
+++ b/ios/Empo/src/Library/GameLibraryView.swift
@@ -17,6 +17,10 @@ struct GameLibraryView: View {
     @State private var showImporter = false
     @State private var showSettings = false
     @State private var errorMessage: String?
+    // TODO(localization): once the app has a strings catalog these
+    // copy fallbacks should move into it alongside the other
+    // user-facing text. Keep the literals here for now so the
+    // existing string-search audit still points at a single spot.
     @State private var errorTitle: String = "Oops!"
     @State private var showErrorAlert = false
     @State private var showCancelValidationAlert = false

--- a/ios/Empo/src/Library/ImportButton.swift
+++ b/ios/Empo/src/Library/ImportButton.swift
@@ -60,6 +60,12 @@ struct ImportButton: View {
                 importButtonLabel(collapsed: collapsed)
             }
             .buttonStyle(.plain)
+            // Label text is either hidden ("+" only, collapsed state)
+            // or localised to "Import game"; either way VoiceOver
+            // needs a stable announcement that doesn't flip between
+            // "Plus button" and "Import game button" during the
+            // collapsed<->expanded morph.
+            .accessibilityLabel(isValidating ? "Cancel import" : "Import game")
             .onChange(of: collapsed) { _, _ in
                 Haptics.tap()
             }

--- a/ios/Empo/src/Player/DebugOverlayView.swift
+++ b/ios/Empo/src/Player/DebugOverlayView.swift
@@ -55,7 +55,7 @@ struct DebugOverlayView: View {
 
             HStack(spacing: Spacing.xs) {
                 Text("\(Int(fps.rounded())) FPS")
-                    .font(.system(size: 17, weight: .bold, design: .monospaced))
+                    .font(AppFont.debugFPS)
                     .foregroundStyle(fpsColor)
 
                 // FPS Graph. Canvas has no intrinsic content size so we
@@ -111,16 +111,17 @@ struct DebugOverlayView: View {
 
     /// Monospaced text row with the overlay's default styling. Wraps
     /// to additional lines when the content exceeds the overlay's
-    /// fixed width instead of truncating.
+    /// fixed width instead of truncating. Font defaults to
+    /// `AppFont.debugBody`; callers that need a bigger/bolder
+    /// variant (e.g. the title line) pass the corresponding token.
     @ViewBuilder
     private func debugText(
         _ text: String,
-        weight: Font.Weight = .medium,
-        size: CGFloat = 13,
+        font: Font = AppFont.debugBody,
         color: Color = .white.opacity(Alpha.textMuted)
     ) -> some View {
         Text(text)
-            .font(.system(size: size, weight: weight, design: .monospaced))
+            .font(font)
             .foregroundStyle(color)
             .multilineTextAlignment(.leading)
             .fixedSize(horizontal: false, vertical: true)
@@ -138,15 +139,15 @@ struct DebugOverlayView: View {
             ViewThatFits(in: .horizontal) {
                 debugText(
                     "\(gameTitle) \u{00B7} RGSS\(rgssVersion)",
-                    weight: .bold, size: 14, color: .white
+                    font: AppFont.debugTitle, color: .white
                 )
                 VStack(alignment: .leading, spacing: Spacing.xxs) {
-                    debugText(gameTitle, weight: .bold, size: 14, color: .white)
-                    debugText("RGSS\(rgssVersion)", weight: .bold, size: 14, color: .white)
+                    debugText(gameTitle, font: AppFont.debugTitle, color: .white)
+                    debugText("RGSS\(rgssVersion)", font: AppFont.debugTitle, color: .white)
                 }
             }
         } else {
-            debugText(gameTitle, weight: .bold, size: 14, color: .white)
+            debugText(gameTitle, font: AppFont.debugTitle, color: .white)
         }
     }
 

--- a/ios/Empo/src/Player/GameControls.swift
+++ b/ios/Empo/src/Player/GameControls.swift
@@ -58,6 +58,13 @@ struct ActionButton: View {
         // the brightness of the game content behind them.
         .darkGlass()
         .contentShape(Circle())
+        // VoiceOver: the visible glyph (`A`, `B`, `X`, `Y`, etc.) reads
+        // as a letter otherwise, which gives no hint that it's a game
+        // input. Announce it explicitly so users know they're holding
+        // a gamepad button. The editing state is announced separately
+        // by the layout's edit-mode container.
+        .accessibilityLabel("\(label) button")
+        .accessibilityAddTraits(.isButton)
         // Touch dispatch. minimumDistance=0 makes this a press-tracking
         // gesture that fires on touch-down (not after a drag threshold).
         // Only install when NOT editing so the parent's drag-to-reposition
@@ -225,6 +232,18 @@ struct DPad: View {
         // engage. The wedge math in updateDirections decides which
         // direction a given touch point represents.
         .contentShape(Circle())
+        // VoiceOver: describe as a directional pad so users know the
+        // control responds to directional gestures rather than
+        // treating it as a decorative glyph. Direction detection is
+        // continuous-touch based so there's no per-direction button
+        // to expose individually.
+        .accessibilityLabel("Directional pad")
+        .accessibilityHint("Touch and drag to move the character")
+        // VoiceOver otherwise swallows the drag gesture because it
+        // interprets taps as element activation. Direct interaction
+        // tells VoiceOver to pass raw touches through so holding
+        // and sliding across directions works with the rotor off.
+        .accessibilityAddTraits(.allowsDirectInteraction)
         .gesture(editing ? nil : dpadGesture)
         .onChange(of: editing) { _, newValue in
             if newValue {


### PR DESCRIPTION
## Summary

Tier 6c of the audit-driven refactor roadmap. Covers the accessibility-gap and misc-polish items that were deferred out of 6a / 6b.

## Accessibility

- `ActionButton` announces as "A button" / "B button" / etc. instead of a bare letter glyph, with `.isButton` trait.
- `DPad` announces as "Directional pad" with a touch-and-drag hint and `.allowsDirectInteraction` so VoiceOver passes raw touches through for continuous direction tracking.
- `ImportButton` gained a stateful `.accessibilityLabel` that toggles between "Import game" and "Cancel import" based on validation state.
- `GameInfoView` replaced a nested `Color.clear.onAppear` inside a `GeometryReader` with `.onGeometryChange(for:of:action:)`. The nav-bar bottom Y used by the title scroll animation now reacts to orientation / size changes instead of only capturing once at appear.
- `GameHeroCard` decorative play / pause icon is now `.accessibilityHidden(true)` - the enclosing Button already announces the resume action and the glyph shouldn't duplicate it.

## Misc

- `GameLibraryView` gained a `TODO(localization)` marker next to the `"Oops!"` / `"Something went wrong."` fallbacks so the future strings-catalog migration has a clear landing point.
- `DebugOverlayView` font sizes routed through the theme. New `AppFont.debugFPS` (17pt) plus sharpened `AppFont.debugBody` (13pt) and `AppFont.debugTitle` (14pt). The helper `debugText(...)` now takes a `Font` token directly instead of raw size/weight pairs.

## Testing

- Simulator build: passes, no new warnings
- Device build: passes
- Verified on both targets.