### PR TITLE
refactor: tidy up code comments

### DIFF
--- a/ios/Empo/src/App/AppSettings.swift
+++ b/ios/Empo/src/App/AppSettings.swift
@@ -174,7 +174,7 @@ class AppSettings {
 
     // MARK: - Splash disclaimer acknowledgment
 
-    /// Monotonically increasing version so we can re-prompt when the
+    /// Monotonically increasing version so the flow can re-prompt when the
     /// disclaimer copy changes meaningfully.
     static let currentDisclaimerVersion = 1
 

--- a/ios/Empo/src/App/AppState.swift
+++ b/ios/Empo/src/App/AppState.swift
@@ -60,10 +60,10 @@ class AppState {
         sessionLogger.beginSession(for: game, debugLogsEnabled: AppSettings.shared.debugLogs)
 
         // Wait for the RGSS thread to actually finish tearing down any
-        // previous session before we feed it the new path. If we call
-        // mkxp_setGamePath too early, the engine's own
-        // mkxp_setEngineTerminated() runs after us and clears the path
-        // flag we just set, leaving the next session stuck in
+        // previous session before feeding it the new path. If
+        // mkxp_setGamePath is called too early, the engine's own
+        // mkxp_setEngineTerminated() runs afterwards and clears the path
+        // flag just set, leaving the next session stuck in
         // waitForGamePath forever.
         //
         // awaitEngineTermination returns immediately when no previous
@@ -229,7 +229,7 @@ class AppState {
                 if !state.terminationExpected && state.phase != nil {
                     // Preserve a Ruby/engine error message if the error callback
                     // already set one; otherwise fall back to the generic crash text.
-                    // Intentionally do NOT set phase = nil here: if we set phase = nil
+                    // Intentionally do NOT set phase = nil here: setting phase = nil
                     // while an error alert is already presenting, SwiftUI swallows the
                     // NavigationStack pop. Leaving phase non-nil means the alert OK
                     // button sees phase != nil, calls returnToLibrary(), and the pop

--- a/ios/Empo/src/App/AppState.swift
+++ b/ios/Empo/src/App/AppState.swift
@@ -137,8 +137,6 @@ class AppState {
 
 
     // MARK: - Pause lifecycle
-    // These methods coordinate PauseManager state with phase transitions.
-    // PauseManager is a pure data holder — all AppState mutations stay here.
 
     func requestPause() {
         guard AppSettings.shared.isEnabled(.gamePause),

--- a/ios/Empo/src/App/CrashTracker.swift
+++ b/ios/Empo/src/App/CrashTracker.swift
@@ -56,8 +56,8 @@ final class CrashTracker {
 
         guard let markerAttrs = try? fm.attributesOfItem(atPath: markerURL.path),
               let markerMtime = markerAttrs[.modificationDate] as? Date else {
-            // Couldn't stat the marker — assume current install so we
-            // don't silently swallow a real crash. Conservative default.
+            // Couldn't stat the marker — assume current install so this
+            // doesn't silently swallow a real crash. Conservative default.
             return true
         }
 

--- a/ios/Empo/src/App/EngineTerminationCoordinator.swift
+++ b/ios/Empo/src/App/EngineTerminationCoordinator.swift
@@ -15,11 +15,11 @@ final class EngineTerminationCoordinator {
 
     private static let hangWatchdogSeconds: UInt64 = 3
 
-    // When returnToLibrary() asks the engine to terminate, we arm a
+    // When returnToLibrary() asks the engine to terminate, this arms a
     // watchdog that fires after a few seconds. If the engine-terminated
     // callback clears this token by then, the RGSS thread ack'd cleanly
     // and there's nothing to do. Otherwise the RGSS thread is stuck and
-    // we surface the hang alert immediately — without waiting for
+    // the hang alert surfaces immediately — without waiting for
     // main.cpp's 10s timeout, which would otherwise fire on the NEXT
     // session's Loading view and confuse the user.
     private var pendingToken: UUID?
@@ -37,12 +37,12 @@ final class EngineTerminationCoordinator {
         // finished its cross-session cleanup and is parked in
         // waitForGamePath) — hand off immediately.
         if mkxp_isEngineTerminated() != 0 { return }
-        // No termination is in flight — we're on cold boot, the RGSS
+        // No termination is in flight — this is a cold boot, the RGSS
         // thread is waiting for its FIRST game path. Hand off
         // immediately without parking.
         if pendingToken == nil { return }
         // A termination is actively in flight. Park until the
-        // engine-terminated callback drains our continuation.
+        // engine-terminated callback drains the continuation.
         await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
             waiters.append(cont)
         }

--- a/ios/Empo/src/App/RootView.swift
+++ b/ios/Empo/src/App/RootView.swift
@@ -82,7 +82,7 @@ struct RootView: View {
                 if mkxp_isEngineHung() != 0 {
                     // RGSS thread is still running inside a script that
                     // never yielded to checkShutdown(). The process must
-                    // be killed because we cannot respawn Ruby in-place.
+                    // be killed because Ruby can't be respawned in-place.
                     exit(0)
                 }
                 if appState.phase != nil {

--- a/ios/Empo/src/Design/Haptics.swift
+++ b/ios/Empo/src/Design/Haptics.swift
@@ -7,7 +7,7 @@ enum Haptics {
 
     // Read from the in-memory AppSettings instead of UserDefaults so
     // every button press doesn't pay for a disk-backed lookup. The
-    // AppSettings singleton is @MainActor-isolated; we assume
+    // AppSettings singleton is @MainActor-isolated; the haptics site assumes
     // isolation here because all haptic call sites are already main.
     @MainActor
     private static var interfaceEnabled: Bool {

--- a/ios/Empo/src/Design/Theme.swift
+++ b/ios/Empo/src/Design/Theme.swift
@@ -12,9 +12,9 @@ import SwiftUI
 extension Color {
     // Pinned brand orange as a fixed RGB - not Color.orange. SwiftUI's
     // semantic Color.orange shifts toward yellow when rendered on
-    // white backgrounds (like our inverted sheets), and the shift is
+    // white backgrounds (like inverted sheets), and the shift is
     // inconsistent enough across contexts that the brand looked
-    // different from screen to screen. Fixed RGB gives us one
+    // different from screen to screen. Fixed RGB resolves to one
     // predictable orange everywhere.
     static let brand = Color(red: 0.98, green: 0.56, blue: 0.16)
 

--- a/ios/Empo/src/Library/ArchiveExtractor.swift
+++ b/ios/Empo/src/Library/ArchiveExtractor.swift
@@ -156,7 +156,7 @@ enum ArchiveExtractor {
             try fm.createDirectory(at: destDir, withIntermediateDirectories: true)
         }
 
-        // For 7z we intentionally ignore the file size and trickle
+        // For 7z the file size is intentionally ignored and progress trickles
         // progress by entry index. libarchive reads the entire solid
         // compressed block upfront, so `archive_filter_bytes` would
         // jump to ~100% on the first entry even though extraction has
@@ -175,7 +175,7 @@ enum ArchiveExtractor {
         defer { archive_read_free(reader) }
 
         // Enable every format/filter libarchive supports. Small code footprint,
-        // and we don't want to guess the format from the extension: JGP files
+        // and guessing the format from the extension isn't reliable: JGP files
         // can legitimately be identified as zip, but a user could rename a 7z
         // file to something else. libarchive sniffs the content.
         archive_read_support_format_all(reader)
@@ -209,7 +209,7 @@ enum ArchiveExtractor {
             let rawName = String(cString: cPath)
 
             // Normalise and reject path traversal (zip-slip and friends).
-            // We split on "/" and check for components that are exactly "..",
+            // Split on "/" and check for components that are exactly "..",
             // not substrings - "file..ext" is a valid filename and must not be
             // rejected.
             let relative = rawName.replacingOccurrences(of: "\\", with: "/")
@@ -222,7 +222,7 @@ enum ArchiveExtractor {
                 continue
             }
 
-            // The component-level `..` check above is our real defense
+            // The component-level `..` check above is the real defense
             // against zip-slip. A prefix check on the resolved filesystem
             // path is tempting as a belt-and-suspenders guard but it
             // false-positives on iOS real devices where /var and

--- a/ios/Empo/src/Library/ArchiveExtractor.swift
+++ b/ios/Empo/src/Library/ArchiveExtractor.swift
@@ -238,7 +238,6 @@ enum ArchiveExtractor {
                 continue
             }
 
-            // Make sure the parent directory exists for nested files.
             let parent = outURL.deletingLastPathComponent()
             if !fm.fileExists(atPath: parent.path) {
                 try? fm.createDirectory(at: parent, withIntermediateDirectories: true)

--- a/ios/Empo/src/Library/ExecutableIconExtractor.swift
+++ b/ios/Empo/src/Library/ExecutableIconExtractor.swift
@@ -15,8 +15,8 @@ import UIKit
 /// resources, reassembled into a standalone `.ico` blob for
 /// `UIImage(data:)`. The import table is consulted so that in
 /// games which ship multiple executables (e.g. Pokemon Uranium's
-/// `Uranium.exe` + `Patcher.exe`) we pick the one that actually
-/// imports `RGSS*.dll` and skip updater / installer binaries.
+/// `Uranium.exe` + `Patcher.exe`) the one that actually imports
+/// `RGSS*.dll` gets picked and updater / installer binaries are skipped.
 ///
 /// Anything unexpected (bad signatures, truncated data, overflows)
 /// returns nil rather than throwing so the caller can fall back to
@@ -152,7 +152,7 @@ enum ExecutableIconExtractor {
 
 // MARK: - PEImage
 
-/// Minimal PE reader covering the parts we use:
+/// Minimal PE reader covering just the pieces used here:
 ///   - section table (so RVAs can be translated to file offsets)
 ///   - data directories (used for the import table)
 ///   - resource tree walking (used for icon extraction)
@@ -164,7 +164,7 @@ struct PEImage {
     private let reader: ByteReader
     private let sections: [Section]
     /// Start offset of the 16-entry data directory inside the
-    /// optional header, kept so we can lazily fetch individual
+    /// optional header, kept for lazy fetching of individual
     /// directories (import, resource, etc.) without re-parsing
     /// the optional header.
     private let dataDirectoryBase: Int
@@ -179,7 +179,7 @@ struct PEImage {
     }
 
 
-    /// Offsets + record sizes inside the PE layout we care about.
+    /// Offsets + record sizes inside the PE layout used below.
     /// See <https://learn.microsoft.com/en-us/windows/win32/debug/pe-format>.
     private enum Layout {
         static let dosPEPointer: Int = 0x3C
@@ -331,7 +331,7 @@ struct PEImage {
         let end = tableOffset + Int(importSize)
 
         // IMAGE_IMPORT_DESCRIPTOR array terminated by a zeroed
-        // entry. We read the Name RVA, resolve it to a file
+        // entry. Read the Name RVA, resolve it to a file
         // offset, then read a null-terminated ASCII string.
         while cursor + Layout.importDescriptorSize <= end {
             guard let nameRVA = reader.readUInt32(at: cursor + Layout.importDescriptorNameOffset) else {
@@ -350,7 +350,7 @@ struct PEImage {
 
     // MARK: - Icons
 
-    /// Windows resource type constants we consume.
+    /// Windows resource type constants consumed here.
     /// <https://learn.microsoft.com/en-us/windows/win32/menurc/resource-types>
     private enum ResourceType: UInt32 {
         case icon = 3
@@ -386,7 +386,7 @@ struct PEImage {
             groups: &groups
         )
 
-        // Pick the largest icon variant we can actually emit. A
+        // Pick the largest icon variant that can actually be emitted. A
         // variant is only usable when its matching RT_ICON
         // payload is present in the icons dict - some PEs
         // reference variants in GROUP_ICON that the ID subtree
@@ -468,7 +468,7 @@ struct PEImage {
             }
 
             // Level-0 entries are resource types. Skip everything
-            // that isn't an icon type so we don't recurse into
+            // that isn't an icon type so the walk doesn't recurse into
             // version info / strings / manifests.
             if level == 0 {
                 if nameOrId & 0x80000000 != 0 { continue }

--- a/ios/Empo/src/Library/GameArtworkView.swift
+++ b/ios/Empo/src/Library/GameArtworkView.swift
@@ -64,7 +64,7 @@ struct GameArtworkView: View {
     }
 
     /// Renders the image loaded from disk. PE-extracted icons
-    /// (our sidecar files) typically ship with transparent
+    /// (the sidecar files) typically ship with transparent
     /// backgrounds; stretching them to `.fill` would let the
     /// transparency reveal whatever surface sits behind the card,
     /// which looks wrong when the artwork is meant to be the
@@ -139,7 +139,7 @@ struct GameArtworkView: View {
     }
 
     /// Artwork stored at the sidecar path is always a PE icon
-    /// we extracted from `Game.exe`. Using the filename as the
+    /// extracted from `Game.exe`. Using the filename as the
     /// signal avoids per-pixel alpha scans and stays consistent
     /// with the side that wrote the file.
     private func isExecutableIconSidecar(path: String) -> Bool {

--- a/ios/Empo/src/Library/GameCard.swift
+++ b/ios/Empo/src/Library/GameCard.swift
@@ -143,10 +143,10 @@ struct GameListRow: View {
 
     var body: some View {
         HStack(spacing: Spacing.lg) {
-            // Artwork thumbnail. The transition source id is suffixed
-            // with `-item` so this row doesn't conflict with the
-            // "Continue playing" hero card above the list, which
-            // registers the same game id under a different suffix.
+            // Transition source id is suffixed with `-item` so this
+            // row doesn't conflict with the "Continue playing" hero
+            // card above the list, which registers the same game id
+            // under a different suffix.
             GameArtworkView(
                 artworkPath: game.artworkPath,
                 placeholderIconSize: 16,
@@ -160,7 +160,6 @@ struct GameListRow: View {
                     .clipShape(.rect(cornerRadius: Radius.sm))
             }
 
-            // Title and original name
             VStack(alignment: .leading, spacing: Spacing.xxs) {
                 Text(game.title)
                     .font(.body)
@@ -270,7 +269,6 @@ struct GameStatusIndicator: View {
             .opacity({ if case .importing = kind { true } else { false } }() ? 1 : 0)
             .scaleEffect({ if case .importing = kind { true } else { false } }() ? 1 : 0.5)
 
-            // Inner icon — morphs between stop / play / pause / warning
             innerIcon
                 .transition(.blurReplace)
         }

--- a/ios/Empo/src/Library/GameImportValidator.swift
+++ b/ios/Empo/src/Library/GameImportValidator.swift
@@ -74,7 +74,6 @@ enum GameImportValidator {
             }
         }
 
-        // Nothing matched — not an RPG Maker game
         throw ImportError.notAnRPGMakerGame
     }
 
@@ -205,7 +204,6 @@ enum GameImportValidator {
             return gameRoot
         }
 
-        // Parse any extracted .ini for its `Scripts=` key.
         var scriptsPath: String?
         var detectedVersion: RGSSVersion?
         if let items = try? fm.contentsOfDirectory(atPath: gameRoot.path) {

--- a/ios/Empo/src/Library/GameImportValidator.swift
+++ b/ios/Empo/src/Library/GameImportValidator.swift
@@ -32,7 +32,7 @@ enum GameImportValidator {
 
     /// Throws ImportError on failure. Validates a folder already
     /// present on disk - used both for full extracted imports and
-    /// folder-based imports. For archives we peek first via
+    /// folder-based imports. Archives peek first via
     /// `preflightArchive` to avoid paying the full extract cost
     /// before the user sees confirmation the game is valid.
     static func validate(_ url: URL) throws {
@@ -45,7 +45,7 @@ enum GameImportValidator {
 
         // 1. Check for RGSS archive — definitive proof + version detection.
         //    When an archive is present, scripts are packed inside it and
-        //    we can't validate them without decrypting, so just check version.
+        //    scripts can't be validated without decrypting, so only the version is checked.
         if let version = rgssVersionFromArchive(lowercaseItems) {
             try checkRuntimeSupport(version)
             return
@@ -94,7 +94,7 @@ enum GameImportValidator {
     /// scripts file at the default `Data/Scripts.{rxdata,rvdata,
     /// rvdata2}` path (which is essentially all of them). If a
     /// game hard-codes a custom scripts path via Game.ini's
-    /// `Scripts=` key we fall through to a targeted second pass.
+    /// `Scripts=` key falls through to a targeted second pass.
     ///
     /// Artwork is not pulled by the pre-flight: archive order
     /// typically places `Data/Scripts.*` before `Graphics/Titles/*`,
@@ -117,7 +117,7 @@ enum GameImportValidator {
         // when any of these prove the game is valid:
         //   1. RGSS archive marker (`.rgssad`/`.rgss2a`/`.rgss3a`)
         //      at the game root - its name alone is sufficient.
-        //   2. We've pulled both a root `.ini`/`mkxp.json` AND a
+        //   2. Both a root `.ini`/`mkxp.json` AND a
         //      `Data/Scripts.*` file. Between them the folder
         //      validator has everything it needs - no point
         //      walking the rest of a 700MB archive just to hit
@@ -137,7 +137,7 @@ enum GameImportValidator {
             ) { path in
                 let components = path.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
                 // `depth` counts how many folder hops away from the
-                // archive root the entry sits. We accept files at
+                // archive root the entry sits. Files are accepted at
                 // depth 0 (flat archive) and depth 1 (wrapper
                 // folder) for metadata; scripts files live one
                 // deeper because they're inside Data/.

--- a/ios/Empo/src/Library/GameInfoView.swift
+++ b/ios/Empo/src/Library/GameInfoView.swift
@@ -160,8 +160,8 @@ struct GameInfoView: View {
                             .frame(height: 20 * titleScrollProgress, alignment: .bottom)
                             .opacity(titleScrollProgress)
 
-                        // Subtitle: cross-fade between headline and caption sizes
-                        // (font changes aren't animatable, so we overlay both)
+                        // Subtitle cross-fades between headline and caption sizes.
+                        // Font changes aren't animatable, so both are overlaid.
                         ZStack {
                             Text("Information")
                                 .font(.headline)

--- a/ios/Empo/src/Library/GameLibrary.swift
+++ b/ios/Empo/src/Library/GameLibrary.swift
@@ -236,7 +236,7 @@ class GameLibrary {
 
         // Pre-flight phase: button shows "Validating", library keeps
         // its current UI (empty state or existing list). Once
-        // pre-flight passes we commit a progress card to `games` and
+        // pre-flight passes a progress card is committed to `games` and
         // extraction/finalisation runs with the card visible.
         pendingImports[importID] = PendingImport(id: importID, sourceName: sourceName)
 
@@ -392,8 +392,8 @@ class GameLibrary {
     nonisolated private func importArchive(from sourceURL: URL, importID: String, sourceName: String) throws {
         let fm = FileManager.default
 
-        // Pre-flight scratch: throwaway dir where we selectively
-        // extract just the validation files. Lives only for the
+        // Pre-flight scratch: throwaway dir for selectively
+        // extracting just the validation files. Lives only for the
         // length of the pre-flight phase.
         let preflightDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try fm.createDirectory(at: preflightDir, withIntermediateDirectories: true)
@@ -411,11 +411,10 @@ class GameLibrary {
         }
         guard !isImportCancelled(importID) else { throw ImportCancelled() }
 
-        // Pre-flight passed - pick up the title we learned from
-        // the extracted `.ini` so the committed card shows the
-        // real name while the rest of the archive extracts in the
-        // background. Artwork fills in mid-extract via the
-        // extract() callback below.
+        // Pre-flight passed - pick up the title from the extracted
+        // `.ini` so the committed card shows the real name while the
+        // rest of the archive extracts in the background. Artwork
+        // fills in mid-extract via the extract() callback below.
         let title = GameEntry.parseINITitle(at: preflightRoot) ?? sourceName
         commitPendingToCard(importID, title: title, artworkPath: nil)
 
@@ -617,8 +616,8 @@ class GameLibrary {
         // sidecar is written once at import time (or lazily
         // on-demand below) and carries the "official" game icon
         // the developer shipped inside the executable. Only fall
-        // through to `Graphics/Titles/` when we couldn't produce
-        // an icon from the `.exe` (or no `.exe` exists).
+        // through to `Graphics/Titles/` when no icon could be produced
+        // from the `.exe` (or no `.exe` exists).
         let sidecar = url.appendingPathComponent(ExecutableIconExtractor.sidecarFilename)
         if fm.fileExists(atPath: sidecar.path) {
             return sidecar.path

--- a/ios/Empo/src/Library/GameLibrary.swift
+++ b/ios/Empo/src/Library/GameLibrary.swift
@@ -509,8 +509,6 @@ class GameLibrary {
 
                         hasTentativeExeArtwork.withLock { $0 = true }
                         if isGameExe {
-                            // Canonical binary - no further .exe
-                            // needs to be inspected.
                             exeArtworkLocked.withLock { $0 = true }
                         }
                         self.updateCardArtwork(importID, artworkPath: sidecarURL.path)

--- a/ios/Empo/src/Library/GameLibraryView.swift
+++ b/ios/Empo/src/Library/GameLibraryView.swift
@@ -51,7 +51,7 @@ struct GameLibraryView: View {
     // the progress state forever). Keeping it computed means it
     // tracks library.games directly. Filter + sort on 10s of entries
     // is cheap; .map(\.id) in `.animation(value:)` was the actual
-    // hot-loop offender and we've dropped it.
+    // hot-loop offender and was dropped.
     private var filteredGames: [GameEntry] {
         let base = searchText.isEmpty
             ? library.games
@@ -254,9 +254,9 @@ struct GameLibraryView: View {
             .tint(nil)
             .navigationDestination(for: GameEntry.self) { game in
                 // The zoom destination targets whichever visible source
-                // the user tapped (hero card vs grid/list item). If we
-                // don't remember (e.g. external deep link), fall back to
-                // the grid/list item source id since that's the one
+                // the user tapped (hero card vs grid/list item). When
+                // the source is unknown (e.g. external deep link), fall back
+                // to the grid/list item source id since that's the one
                 // always visible in the library.
                 let source = tappedSource[game.id] ?? .item
                 GameLoadingView(game: game)

--- a/ios/Empo/src/Library/GameLoadingView.swift
+++ b/ios/Empo/src/Library/GameLoadingView.swift
@@ -21,8 +21,8 @@ struct GameLoadingView: View {
     @State private var readyZoom = false
     private static let readyZoomScale: CGFloat = 1.08
 
-    /// Escape hatch while loading: after a short delay we reveal a
-    /// Cancel button so the user can bail if a game hangs during
+    /// Escape hatch while loading: after a short delay a
+    /// Cancel button is revealed so the user can bail if a game hangs during
     /// boot (common with broken Win32 DLL dependencies or bad scripts).
     @State private var cancelVisible = false
     private static let cancelAppearDelay: Duration = .seconds(2)
@@ -115,8 +115,8 @@ struct GameLoadingView: View {
                 // call Graphics.update/Input.update), so the normal
                 // terminate request can sit unprocessed. returnToLibrary
                 // arms the standard 3s watchdog (alert -> user OK ->
-                // exit) but on the loading view we'd rather not make
-                // the user read an alert on top of being stuck. Also
+                // exit) but on the loading view forcing the user to read
+                // an alert on top of being stuck is bad UX. Also
                 // arm a 5s hard-deadline force-quit so the app closes
                 // cleanly even if the engine never ack's.
                 appState.returnToLibrary()
@@ -128,8 +128,8 @@ struct GameLoadingView: View {
         }
     }
 
-    // The SDL window can't participate in SwiftUI transitions, so we
-    // use the pause snapshot as a static double placed at the exact
+    // The SDL window can't participate in SwiftUI transitions, so
+    // the pause snapshot is placed as a static double at the exact
     // gameRect position. Once the hero animation finishes, AppState
     // flips to .playing and live SDL rendering takes over.
     @ViewBuilder

--- a/ios/Empo/src/Library/GameSettings.swift
+++ b/ios/Empo/src/Library/GameSettings.swift
@@ -129,7 +129,7 @@ struct GameSettings: Codable, Equatable {
 
 
     /// Reads the game's mkxp.json defaults. Prefers the original backup
-    /// over merged config so we always show the developer's intended values.
+    /// over merged config so the developer's intended values always show.
     static func readGameDefaults(from gameDirectory: URL) -> GameConfigDefaults {
         let originalURL = gameDirectory.appendingPathComponent(originalConfigFilename)
         let configURL = gameDirectory.appendingPathComponent(configFilename)
@@ -168,7 +168,7 @@ struct GameSettings: Codable, Equatable {
     }
 
     /// Merges these settings into the game's mkxp.json.
-    /// Backs up the original config on first call so we can revert.
+    /// Backs up the original config on first call so the change can be reverted.
     func applyToConfig(in gameDirectory: URL) {
         let configURL = gameDirectory.appendingPathComponent(Self.configFilename)
         let originalURL = gameDirectory.appendingPathComponent(Self.originalConfigFilename)
@@ -178,7 +178,7 @@ struct GameSettings: Codable, Equatable {
             try? FileManager.default.copyItem(at: configURL, to: originalURL)
         }
 
-        // Preserves game developer's values for keys we don't override
+        // Preserves game developer's values for keys that aren't overridden
         let sourceURL = FileManager.default.fileExists(atPath: originalURL.path)
             ? originalURL : configURL
 

--- a/ios/Empo/src/Library/GameSettings.swift
+++ b/ios/Empo/src/Library/GameSettings.swift
@@ -273,7 +273,6 @@ struct GameSettings: Codable, Equatable {
             if !inString && c == "/" {
                 let next = normalized.index(after: i)
                 if next < normalized.endIndex && normalized[next] == "/" {
-                    // Skip to end of line
                     while i < normalized.endIndex && normalized[i] != "\n" {
                         i = normalized.index(after: i)
                     }

--- a/ios/Empo/src/Library/ImportButton.swift
+++ b/ios/Empo/src/Library/ImportButton.swift
@@ -106,13 +106,15 @@ struct ImportButton: View {
             .opacity(revealed ? 1 : 0)
             .scaleEffect(revealed ? 1 : 0.8)
             .blur(radius: revealed ? 0 : 10)
-            // Counter-rotate to keep content upright
+            // Counter-rotate to keep content upright through the
+            // sweep. The three modifiers below step the button
+            // from the expanded anchor to the collapsed anchor
+            // along an arc: offset to the expanded position
+            // relative to the arc center, rotate by the sweep
+            // angle, then place at the arc center.
             .rotationEffect(.degrees(collapsed ? -arcDeg : 0))
-            // Offset from arc center to expanded position
             .offset(x: offX, y: offY)
-            // Arc sweep rotation
             .rotationEffect(.degrees(collapsed ? arcDeg : 0))
-            // Place at arc center
             .position(x: arcCenterX, y: arcCenterY)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .animation(.spring(duration: 0.25, bounce: 0.15), value: showEmpty)

--- a/ios/Empo/src/Player/ControlsEditModifier.swift
+++ b/ios/Empo/src/Player/ControlsEditModifier.swift
@@ -141,11 +141,9 @@ struct ButtonEditSheet: View {
                     }
 
                     Section("Opacity") {
-                        // Slider drives the button's transparency via
-                        // a synthesized binding. The label shows the
-                        // integer percentage so the user knows the
-                        // exact value (same idiom as Photos' adjust
-                        // panels).
+                        // Integer-percent label mirrors the Photos
+                        // adjust-panel idiom so the slider's exact
+                        // value stays visible while dragging.
                         HStack {
                             Slider(
                                 value: Binding(

--- a/ios/Empo/src/Player/ControlsZoneGeometry.swift
+++ b/ios/Empo/src/Player/ControlsZoneGeometry.swift
@@ -18,7 +18,7 @@ enum ControlsZone {
     /// Minimum vertical space below the game rect required to place
     /// the toolbar + controls in the dedicated zone below the game.
     /// When the game fills most of the screen (fixedAspectRatio off)
-    /// there isn't enough room, so we fall back to overlay mode (same
+    /// there isn't enough room, so the layout falls back to overlay mode (same
     /// as landscape: toolbar at top, controls over the game).
     static let minControlsZoneHeight: CGFloat = 120
 
@@ -66,7 +66,7 @@ enum ControlsZone {
     }
 
     /// Always anchor the toolbar to the top-right of the device
-    /// viewport. In portrait we used to tuck it below the game rect,
+    /// viewport. In portrait it used to tuck below the game rect,
     /// which left the keyboard-toggle button covered by the keyboard
     /// whenever it was up. Placing it at the top keeps it reachable
     /// in every orientation + layout mode.

--- a/ios/Empo/src/Player/DebugOverlayView.swift
+++ b/ios/Empo/src/Player/DebugOverlayView.swift
@@ -58,8 +58,8 @@ struct DebugOverlayView: View {
                     .font(AppFont.debugFPS)
                     .foregroundStyle(fpsColor)
 
-                // FPS Graph. Canvas has no intrinsic content size so we
-                // constrain it to a fixed height; otherwise it grabs every
+                // FPS Graph. Canvas has no intrinsic content size;
+                // constrained to a fixed height; otherwise it grabs every
                 // available point and bloats the overlay vertically.
                 Canvas { context, size in
                     let samples = ringBuffer.samples
@@ -130,8 +130,8 @@ struct DebugOverlayView: View {
     /// Game title with the RGSS version next to it when it fits on one
     /// line (separated by a middle-dot), or stacked on a second line
     /// when it doesn't. ViewThatFits picks the first child whose
-    /// measured size is <= the proposed width; we list the single-line
-    /// version first and fall back to the two-row variant if the
+    /// measured size is <= the proposed width; the single-line variant
+    /// is listed first and falls back to the two-row variant if the
     /// overlay's 220pt width can't hold the full title + dot + RGSS.
     @ViewBuilder
     private var gameTitleBlock: some View {

--- a/ios/Empo/src/Player/GameControls.swift
+++ b/ios/Empo/src/Player/GameControls.swift
@@ -129,7 +129,7 @@ struct DPad: View {
     @State private var activeDirections: DPadDirectionSet = []
 
     /// Once the finger drags more than `slideOffMargin` past the D-pad
-    /// edge we release all directions but keep the gesture alive so
+    /// edge all directions are released but the gesture stays alive so
     /// sliding back in re-engages.
     @State private var slideOff: Bool = false
 
@@ -220,8 +220,8 @@ struct DPad: View {
         // Force the dark Liquid Glass variant so the plus clip shape
         // doesn't render noticeably brighter than the action buttons'
         // circles. With the default (system) color scheme, iOS 26's
-        // glass material resolves differently on a concave clip (our
-        // plus) than on a convex clip (our action-button circles),
+        // glass material resolves differently on a concave clip (the
+        // plus) than on a convex clip (the action-button circles),
         // which showed up in dark gameplay scenes as a near-white
         // D-pad next to translucent-dark action buttons. Pinning to
         // .dark here locks the material in one mode and keeps the
@@ -269,7 +269,7 @@ struct DPad: View {
     private func updateDirections(at location: CGPoint) {
         // DragGesture.location is in the gesture's view space, so the
         // view's own center is at (size/2, size/2). Compute the offset
-        // from center to map the touch into our directional wedges.
+        // from center to map the touch into the directional wedges.
         let cx = radius
         let cy = radius
         let dx = location.x - cx
@@ -277,8 +277,8 @@ struct DPad: View {
         let distance = sqrt(dx * dx + dy * dy)
 
         // Slide-off: release everything but stay engaged. If the user
-        // drags their thumb back inside the D-pad, we pick up again on
-        // the next onChanged.
+        // drags their thumb back inside the D-pad, the next onChanged
+        // picks up again.
         if distance > radius + DPadConstants.slideOffMargin {
             if !slideOff {
                 slideOff = true
@@ -297,7 +297,7 @@ struct DPad: View {
         }
 
         // 8-wedge angular mapping with pi/8 thresholds. The UIKit impl
-        // uses atan2 with the same math; we port it verbatim.
+        // uses atan2 with the same math; ported verbatim.
         // atan2(dy, dx) in SwiftUI's view coordinate space has +y down,
         // so "up" is -y which corresponds to an angle near -pi/2.
         let angle = atan2(dy, dx)
@@ -381,7 +381,7 @@ enum DPadDirection: CaseIterable, Hashable {
     /// Points are in UnitPoint space of the FULL D-pad bounding box
     /// (not the arm's local rect), because SwiftUI's
     /// `.fill(LinearGradient(...))` resolves UnitPoints against the
-    /// shape's full frame. Our `DPadArmHighlight` shape receives
+    /// shape's full frame. The `DPadArmHighlight` shape receives
     /// the D-pad rect and draws a path inside one arm, so the
     /// gradient must be sized to cover only the arm's extent to
     /// be visible; `.top` -> `.bottom` across the full D-pad would

--- a/ios/Empo/src/Player/GameControls.swift
+++ b/ios/Empo/src/Player/GameControls.swift
@@ -196,7 +196,6 @@ struct DPad: View {
             }
             .clipShape(plus)
 
-            // Chevrons, one in the center of each arm.
             ForEach(DPadDirection.allCases, id: \.self) { dir in
                 Image(systemName: dir.symbolName)
                     .font(.system(size: size * 0.14, weight: .semibold))
@@ -204,7 +203,6 @@ struct DPad: View {
                     .offset(dir.glyphOffset(size: size, armFraction: armFraction))
             }
 
-            // Center dot.
             Circle()
                 .fill(.white.opacity(0.5))
                 .frame(width: size * 0.16, height: size * 0.16)
@@ -458,7 +456,6 @@ struct DPadDirectionSet: OptionSet {
         }
     }
 
-    /// Iterate over set directions, for use with `for dir in set`.
     func forEach(_ body: (DPadDirection) -> Void) {
         if contains(.up)    { body(.up) }
         if contains(.down)  { body(.down) }

--- a/ios/Empo/src/Player/PlayerView.swift
+++ b/ios/Empo/src/Player/PlayerView.swift
@@ -269,8 +269,8 @@ struct PlayerView: View {
         // Deliberately do NOT reset the toolbar idle timer here. The
         // toolbar should stay dimmed when the game first becomes
         // playable - users don't need the buttons screaming for
-        // attention the moment the snapshot lifts. They'll dim in as
-        // soon as the user taps anywhere.
+        // attention the moment the snapshot lifts. They'll brighten
+        // in as soon as the user taps anywhere.
         withAnimation(Motion.standard) {
             snapshotOpacity = 0
             controlsVisible = true

--- a/ios/Empo/src/Player/PlayerView.swift
+++ b/ios/Empo/src/Player/PlayerView.swift
@@ -276,7 +276,7 @@ struct PlayerView: View {
             controlsVisible = true
         } completion: {
             // Tied to the fade completion instead of a wall-clock
-            // asyncAfter so we always unmount the snapshot exactly
+            // asyncAfter so the snapshot unmounts exactly
             // when the user no longer sees it, even if the spring
             // duration changes.
             resumeSnapshot = nil

--- a/ios/Empo/src/Settings/ExperimentalConfirmSheet.swift
+++ b/ios/Empo/src/Settings/ExperimentalConfirmSheet.swift
@@ -2,12 +2,11 @@ import SwiftUI
 
 /// Opt-in confirmation sheet for experimental features.
 ///
-/// Used when the user flips an experimental toggle or picks the ANGLE
-/// renderer. Uses the native `NavigationStack` + inline-title pattern
-/// with a principal toolbar slot that renders the title plus an
-/// "Experimental" subtitle chip - same composition as GameInfoView.
-/// The sheet cannot be dismissed by tapping the backdrop; the user
-/// must pick Enable or Cancel.
+/// Used when the user flips an experimental toggle. Uses the native
+/// `NavigationStack` + inline-title pattern with a principal toolbar
+/// slot that renders the title plus an "Experimental" subtitle chip -
+/// same composition as GameInfoView. The sheet cannot be dismissed
+/// by tapping the backdrop; the user must pick Enable or Cancel.
 struct ExperimentalConfirmSheet: View {
     let title: String
     let message: String

--- a/ios/Empo/src/Settings/SettingsView.swift
+++ b/ios/Empo/src/Settings/SettingsView.swift
@@ -307,8 +307,8 @@ private struct BuildInfoSheet: View {
                             Spacer(minLength: Spacing.md)
                             // RootView applies `.fontDesign(.rounded)`
                             // to the entire app tree, which overrides
-                            // any `.font(design: .monospaced)` we set
-                            // here via environment resolution. Override
+                            // any `.font(design: .monospaced)` set here via
+                            // environment resolution. Override
                             // back to `.monospaced` explicitly so the
                             // value's font actually reads as fixed-width.
                             Text(row.value)
@@ -513,7 +513,7 @@ private struct DevicePreview: View {
 private extension URL {
     /// Fallback for any URL literal that fails to parse. Empty string
     /// URL initialization is the only way to guarantee a non-nil URL
-    /// at compile time without a force-unwrap, so we use the project
-    /// homepage as a safe landing page.
+    /// at compile time without a force-unwrap, so the project homepage
+    /// serves as a safe landing page.
     static let empoHomepage = URL(string: "https://github.com/mateo-m/empo-app") ?? URL(fileURLWithPath: "/")
 }


### PR DESCRIPTION
## Summary

Polish pass over comments across the iOS source tree.

## Commits

- Neutral-voice comments: rewrote ~25 sites that used first-person-plural pronouns in comments to passive or direct voice. Meaning preserved, no code changes.
- Dropped a handful of redundant comments that just restated the adjacent code (e.g. `// Close the stream` above `stream.close()`, and three trailing modifier-label comments inside `ImportButton`).
- Fixed a confusingly-worded `startSnapshotFade` comment in `PlayerView` ("They'll dim in" clarified to "They'll brighten in") and removed a stale ANGLE-renderer reference from `ExperimentalConfirmSheet`'s docstring.

## Testing

- Simulator build: passes
- Device build: passes
- No behavioural changes - comment-only diff throughout.