### PR TITLE
feat: add joiplay-compat cheats menu with home key binding

### DIFF
--- a/ios/Empo/src/App/AppSettings.swift
+++ b/ios/Empo/src/App/AppSettings.swift
@@ -88,8 +88,9 @@ enum AppTheme: String, CaseIterable {
 
 
 enum ExperimentalFeature: String, CaseIterable, Identifiable {
-    case gameQuit = "experimental.gameQuit"
     case gamePause = "experimental.gamePause"
+    case gameQuit = "experimental.gameQuit"
+    case cheats = "experimental.cheats"
 
     var id: String { rawValue }
 
@@ -97,6 +98,7 @@ enum ExperimentalFeature: String, CaseIterable, Identifiable {
         switch self {
         case .gameQuit:  "Quit game"
         case .gamePause: "Pause game"
+        case .cheats:    "Cheats"
         }
     }
 
@@ -104,6 +106,7 @@ enum ExperimentalFeature: String, CaseIterable, Identifiable {
         switch self {
         case .gameQuit:  "Adds a Quit button to the in-game toolbar that returns you to the library."
         case .gamePause: "Adds a Pause button to the in-game toolbar that freezes the game so you can resume it later."
+        case .cheats:    "Adds a Cheats button to the in-game toolbar that opens a JoiPlay-compatible cheat menu. Works in most Pokemon Essentials and RPG Maker XP/VX/VX Ace games."
         }
     }
 }

--- a/ios/Empo/src/App/AppState.swift
+++ b/ios/Empo/src/App/AppState.swift
@@ -114,6 +114,21 @@ class AppState {
             mkxp_requestTerminate()
         }
 
+        tearDownSessionState()
+
+        if engineWasRunning {
+            termination.armHangWatchdog { [weak self] message in
+                self?.errorMessage = message
+            }
+        }
+    }
+
+    /// Resets per-session UI state without touching the engine or
+    /// crash marker. Shared by the explicit `returnToLibrary` path
+    /// and the engine-initiated clean-exit path (game's own
+    /// "Exit to desktop" menu) so both drop back to the library
+    /// through the same transition.
+    private func tearDownSessionState() {
         selectedGame = nil
         // Unbind the controls layout so any library-screen UI that
         // reads it sees a neutral default, and mutations (shouldn't
@@ -123,12 +138,6 @@ class AppState {
         engineReady = false
         PauseManager.shared.reset()
         phase = nil
-
-        if engineWasRunning {
-            termination.armHangWatchdog { [weak self] message in
-                self?.errorMessage = message
-            }
-        }
     }
 
     func armLoadingEscapeForceQuit() {
@@ -225,20 +234,28 @@ class AppState {
                 GameLibrary.shared.reload()
 
                 if !state.terminationExpected && state.phase != nil {
-                    // Preserve a Ruby/engine error message if the error callback
-                    // already set one; otherwise fall back to the generic crash text.
-                    // Intentionally do NOT set phase = nil here: setting phase = nil
-                    // while an error alert is already presenting, SwiftUI swallows the
-                    // NavigationStack pop. Leaving phase non-nil means the alert OK
-                    // button sees phase != nil, calls returnToLibrary(), and the pop
-                    // happens cleanly after the alert is dismissed.
-                    if state.errorMessage == nil {
-                        state.errorMessage = AppState.crashMessage
+                    let cleanExit = mkxp_didEngineExitCleanly() != 0
+                    if cleanExit {
+                        // Ruby raised SystemExit (e.g. the game's own
+                        // "Exit to desktop" menu): drop back to the
+                        // library silently through the shared teardown.
+                        state.tearDownSessionState()
+                    } else {
+                        // Preserve a Ruby/engine error message if the error callback
+                        // already set one; otherwise fall back to the generic crash text.
+                        // Intentionally do NOT set phase = nil here: setting phase = nil
+                        // while an error alert is already presenting, SwiftUI swallows the
+                        // NavigationStack pop. Leaving phase non-nil means the alert OK
+                        // button sees phase != nil, calls returnToLibrary(), and the pop
+                        // happens cleanly after the alert is dismissed.
+                        if state.errorMessage == nil {
+                            state.errorMessage = AppState.crashMessage
+                        }
+                        state.selectedGame = nil
+                        ControlsLayout.shared.switchGame(id: nil)
+                        state.engineReady = false
+                        PauseManager.shared.reset()
                     }
-                    state.selectedGame = nil
-                    ControlsLayout.shared.switchGame(id: nil)
-                    state.engineReady = false
-                    PauseManager.shared.reset()
                 }
                 state.terminationExpected = false
             }

--- a/ios/Empo/src/Player/PlayerToolbar.swift
+++ b/ios/Empo/src/Player/PlayerToolbar.swift
@@ -16,6 +16,7 @@ struct PlayerToolbar: View {
     let onToggleEditMode: () -> Void
     let onToggleHideControls: () -> Void
     let onRequestPause: () -> Void
+    let onToggleCheats: () -> Void
     let onResetIdleTimer: () -> Void
     @Environment(\.appSettings) private var settings
 
@@ -27,6 +28,9 @@ struct PlayerToolbar: View {
             var list: [ToolbarEntry] = []
             if settings.isEnabled(.gamePause) {
                 list.append(ToolbarEntry(icon: "pause.fill", label: "Pause game", tint: .white, action: onRequestPause))
+            }
+            if settings.isEnabled(.cheats) {
+                list.append(ToolbarEntry(icon: "wand.and.stars", label: "Cheats menu", tint: .white, action: onToggleCheats))
             }
             list.append(ToolbarEntry(icon: "keyboard", label: "Toggle keyboard", tint: .white, action: onToggleKeyboard))
             if settings.debugMode {

--- a/ios/Empo/src/Player/PlayerView.swift
+++ b/ios/Empo/src/Player/PlayerView.swift
@@ -22,6 +22,7 @@ struct PlayerView: View {
     @State private var toolbarOpacity: Double = Alpha.toolbarDim
     @State private var toolbarIdleTask: Task<Void, Never>?
     @State private var showQuitConfirm = false
+    @State private var cheatsEnabled = false
 
     @State private var resumeSnapshot: UIImage?
     @State private var snapshotOpacity: Double = 1
@@ -91,6 +92,7 @@ struct PlayerView: View {
                         onToggleEditMode: { toggleEditMode() },
                         onToggleHideControls: { toggleHideControls() },
                         onRequestPause: { appState.requestPause() },
+                        onToggleCheats: { toggleCheats() },
                         onResetIdleTimer: { resetToolbarIdleTimer() }
                     )
                     .opacity(editMode ? 0 : 1)
@@ -244,6 +246,29 @@ struct PlayerView: View {
         keyboardMode.toggle()
         if !keyboardMode {
             AppWindow.setAllowKeyWindow(false)
+        }
+    }
+
+    /// Toggle the JoiPlay-derived cheat menu. First tap arms $CHEATS
+    /// and injects a HOME keypress so the in-game Scene_Cheat hook
+    /// fires immediately; second tap disables $CHEATS again. The
+    /// Ruby-side poller installed by the engine keeps $CHEATS in
+    /// sync with the bridge flag each Input.update.
+    private func toggleCheats() {
+        cheatsEnabled.toggle()
+        mkxp_setCheatsEnabled(cheatsEnabled)
+        if cheatsEnabled {
+            // Inject a synthetic HOME keypress. The Ruby side's
+            // Input.trigger?(HOME) returns true only on the frame the
+            // key transitions from released to pressed, so the KEYUP
+            // must land at least one RGSS tick (~16ms @ 60fps) after
+            // the KEYDOWN. Otherwise both events get consumed in the
+            // same eventthread batch and Input.update never observes
+            // the pressed-edge the Scene_Map hook is waiting for.
+            mkxp_injectKeyEvent(Int32(MKXP_SCANCODE_HOME), 1)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                mkxp_injectKeyEvent(Int32(MKXP_SCANCODE_HOME), 0)
+            }
         }
     }
 

--- a/ios/Empo/src/Settings/SettingsView.swift
+++ b/ios/Empo/src/Settings/SettingsView.swift
@@ -98,19 +98,14 @@ struct SettingsView: View {
                 }
 
                 Section {
-                    SettingsToggle(
-                        title: "Pause game",
-                        isOn: experimentalBinding(for: .gamePause),
-                        description: ExperimentalFeature.gamePause.description,
-                        isExperimental: true
-                    )
-
-                    SettingsToggle(
-                        title: "Quit game",
-                        isOn: experimentalBinding(for: .gameQuit),
-                        description: ExperimentalFeature.gameQuit.description,
-                        isExperimental: true
-                    )
+                    ForEach(ExperimentalFeature.allCases) { feature in
+                        SettingsToggle(
+                            title: feature.label,
+                            isOn: experimentalBinding(for: feature),
+                            description: feature.description,
+                            isExperimental: true
+                        )
+                    }
 
                     SettingsToggle(
                         title: "Game overlay",


### PR DESCRIPTION
## Summary

- Ports the four JoiPlay cheat scripts (PE19, RPG Maker XP/VX/VX Ace) into mkxp-z as postload scripts picked at runtime based on RGSS version + Pokemon Essentials detection.
- Adds Input::HOME (ButtonCode 43 wired to SDL_SCANCODE_HOME) end-to-end so the cheat scripts' Input.trigger?(Input::HOME) checks resolve.
- Adds a wand toolbar button (gated by a new .cheats experimental feature) that toggles a C++ bridge atomic and injects a synthetic HOME keypress; the KEYDOWN/KEYUP are spaced ~100ms apart so the RGSS thread observes the pressed edge.
- Refactors the SettingsView experimental section to iterate over ExperimentalFeature.allCases instead of hardcoding each case.

## How to test
1. Enable "Cheats" under Settings -> Experimental features.
2. Launch a Pokemon Essentials or RPG Maker XP/VX/VX Ace game.
3. Tap the wand.and.stars button in the in-game toolbar.