### PR TITLE
feat: port joiplay deferred shims (http, script patcher, dl::cfunc)

### DIFF
--- a/ios/Empo/project.yml
+++ b/ios/Empo/project.yml
@@ -129,6 +129,7 @@ targets:
       - path: ../../mkxp-z-apple-mobile/src/main.cpp
       - path: ../../mkxp-z-apple-mobile/src/eventthread.cpp
       - path: ../../mkxp-z-apple-mobile/src/sharedstate.cpp
+      - path: ../../mkxp-z-apple-mobile/src/patcher.cpp
       - path: ../../mkxp-z-apple-mobile/src/config.cpp
       - path: ../../mkxp-z-apple-mobile/src/crypto/rgssad.cpp
       - path: ../../mkxp-z-apple-mobile/src/util/iniconfig.cpp


### PR DESCRIPTION
## Summary

Ships the last batch of JoiPlay compat audit items:

- **HTTP module shim** (`scripts/preload/http_compat.rb`) exposes `HTTP.get(host, query)`, `HTTP.post(host, query, body)`, `HTTP.download(...)` wrapping our native `HTTPLite` so fangames with GameJolt / version-check / update-check code hit a working API instead of `NoMethodError`.
- **Script text-patcher** (`src/patcher.{h,cpp}` + sharedstate integration) lets per-game fixes ship as JSON rules applied to RGSS script text at load time. Matches JoiPlay's `patcher.cpp` 1:1. Config key `patches` (matches JoiPlay); upstream mkxp-z's filesystem-overlay field renamed to `patchPaths` (self-documenting; preserved semantics).
- **DL::CFunc legacy stub** (added to `platform_compat.rb`) handles the older `require 'dl'` / `DL.dlopen('user32')['GetSystemMetrics']` pattern that a few old PE forks and plugins use. Returns a populated hash so the indexing works; `CFunc#call` delegates to `Win32API` which we already route to safe defaults.
- **Encoding constants** intentionally skipped: we ship Ruby 3.1 which has native `Encoding::UTF_8` etc. as proper `Encoding` instances, so fangames that feature-detect don't need JoiPlay's string-override.

Also:
- Registers `patcher.cpp` in `ios/Empo/project.yml` (xcodegen source of truth) so fresh clones pick it up.

## How to test
1. Launch any Pokemon Essentials fangame; confirm it still boots and the cheat menu still works.
2. Optionally point `mkxp.json`'s `patches` at a JSON file with `{"rpgm":[{"key":"...","value":"..."}]}` rules to verify the patcher applies rewrites (look for "Patcher: applied ..." log lines).

Closes the JoiPlay compat audit backlog.