### PR TITLE
feat: joiplay jgp archives, reborn compat shims, keyboard groundwork

### DIFF
--- a/ios/Empo/Info.plist
+++ b/ios/Empo/Info.plist
@@ -49,5 +49,40 @@
 	<string>Take a photo to use as custom game artwork or banner.</string>
 	<key>LSSupportsGameMode</key>
 	<true/>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>cyou.joiplay.jgp</string>
+			<key>UTTypeDescription</key>
+			<string>JoiPlay Archive</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.zip-archive</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>jgp</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>JoiPlay Archive</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>cyou.joiplay.jgp</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/ios/Empo/src/Library/DocumentPickerView.swift
+++ b/ios/Empo/src/Library/DocumentPickerView.swift
@@ -5,6 +5,15 @@ import UniformTypeIdentifiers
 extension UTType {
     static let sevenZArchive = UTType(filenameExtension: "7z") ?? .archive
     static let rarArchive    = UTType(filenameExtension: "rar") ?? .archive
+    /// JoiPlay archive. Declared via `exportedAs` in Info.plist so
+    /// Files.app can open .jgp with us, but we look up the
+    /// filename-extension-based UTType first so the document picker
+    /// accepts .jgp even when the Launch Services index hasn't
+    /// caught up (first run after install, or simulator state).
+    /// Falling back to our exported type matches how 7z/rar behave.
+    static let jgpArchive    = UTType(filenameExtension: "jgp")
+                               ?? UTType(exportedAs: "cyou.joiplay.jgp",
+                                         conformingTo: .zip)
 }
 
 
@@ -13,7 +22,7 @@ struct DocumentPickerView: UIViewControllerRepresentable {
 
     func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
         let picker = UIDocumentPickerViewController(
-            forOpeningContentTypes: [.folder, .zip, .sevenZArchive, .rarArchive]
+            forOpeningContentTypes: [.folder, .zip, .sevenZArchive, .rarArchive, .jgpArchive]
         )
         picker.allowsMultipleSelection = true
         picker.delegate = context.coordinator

--- a/ios/Empo/src/Library/GameCard.swift
+++ b/ios/Empo/src/Library/GameCard.swift
@@ -55,8 +55,8 @@ struct GameCard: View {
                         .minimumScaleFactor(0.75)
                         .multilineTextAlignment(.leading)
 
-                    if let originalTitle = game.originalTitle {
-                        Text(originalTitle)
+                    if let engineTitle = game.engineTitle {
+                        Text(engineTitle)
                             .font(.caption2)
                             .foregroundStyle(.white.opacity(Alpha.textMuted))
                             .textShadow()
@@ -95,8 +95,8 @@ struct GameCard: View {
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: .infinity)
 
-                if let originalTitle = game.originalTitle {
-                    Text(originalTitle)
+                if let engineTitle = game.engineTitle {
+                    Text(engineTitle)
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
@@ -167,8 +167,8 @@ struct GameListRow: View {
                     .foregroundStyle(.primary)
                     .lineLimit(1)
 
-                if let originalTitle = game.originalTitle {
-                    Text(originalTitle)
+                if let engineTitle = game.engineTitle {
+                    Text(engineTitle)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)

--- a/ios/Empo/src/Library/GameEntry.swift
+++ b/ios/Empo/src/Library/GameEntry.swift
@@ -19,9 +19,16 @@ enum GameStatus: Hashable {
 struct GameEntry: Identifiable, Hashable {
     let id: String           // UUID used as folder name
     let path: String         // full path to game folder
-    let title: String        // display title (custom override or original)
+    let title: String        // display title (custom override or base)
     let artworkPath: String? // first image in Graphics/Titles/, if any
-    var originalTitle: String? = nil // from Game.ini — non-nil only when a custom title is set
+    // The engine's own title for the game (parsed from Game.ini),
+    // surfaced on the library card alongside `title` when they
+    // differ. Non-nil only when the display title has been
+    // overridden - by a user-set customTitle or a JGP manifest
+    // name - so users can still see what the game calls itself
+    // inside the RGSS runtime. nil means `title` IS the engine
+    // title and showing it twice would be redundant.
+    var engineTitle: String? = nil
     var lastPlayed: Date? = nil      // from metadata, cached at scan time
     var status: GameStatus = .ready
 
@@ -37,7 +44,7 @@ struct GameEntry: Identifiable, Hashable {
 
     func hash(into hasher: inout Hasher) { hasher.combine(id) }
     static func == (lhs: GameEntry, rhs: GameEntry) -> Bool {
-        lhs.id == rhs.id && lhs.status == rhs.status && lhs.title == rhs.title && lhs.path == rhs.path && lhs.artworkPath == rhs.artworkPath && lhs.originalTitle == rhs.originalTitle && lhs.lastPlayed == rhs.lastPlayed
+        lhs.id == rhs.id && lhs.status == rhs.status && lhs.title == rhs.title && lhs.path == rhs.path && lhs.artworkPath == rhs.artworkPath && lhs.engineTitle == rhs.engineTitle && lhs.lastPlayed == rhs.lastPlayed
     }
 
 

--- a/ios/Empo/src/Library/GameImportValidator.swift
+++ b/ios/Empo/src/Library/GameImportValidator.swift
@@ -10,6 +10,8 @@ enum GameImportValidator {
         case unsupportedRuntime(String)
         case missingScripts(String)
         case invalidScripts(String)
+        // JoiPlay .jgp specific
+        case invalidJgpManifest
 
         var errorDescription: String? {
             switch self {
@@ -25,6 +27,8 @@ enum GameImportValidator {
                 return "Script file not found: \(path)"
             case .invalidScripts(let path):
                 return "Script file is not a valid RGSS data file: \(path)"
+            case .invalidJgpManifest:
+                return "The JoiPlay archive is missing or has an invalid manifest.json."
             }
         }
     }

--- a/ios/Empo/src/Library/GameInfoView.swift
+++ b/ios/Empo/src/Library/GameInfoView.swift
@@ -27,7 +27,16 @@ struct GameInfoView: View {
         _editingTitle = State(initialValue: meta.customTitle ?? "")
 
         let gameDir = URL(fileURLWithPath: game.path)
-        self.originalTitle = GameEntry.parseINITitle(at: gameDir) ?? "Unknown Game"
+        // Title shown when the user hasn't set a customTitle. For
+        // JGP imports this is the manifest name; for plain
+        // folder/zip imports it's the Game.ini title. The label
+        // under the text field (and the text-field placeholder)
+        // both track this so resetting the custom title gives the
+        // user back what the import originally showed, not the
+        // raw Game.ini one which may be uglier.
+        self.originalTitle = meta.baseTitle
+            ?? GameEntry.parseINITitle(at: gameDir)
+            ?? "Unknown Game"
     }
 
     private var bannerImage: UIImage? {

--- a/ios/Empo/src/Library/GameLibrary.swift
+++ b/ios/Empo/src/Library/GameLibrary.swift
@@ -150,18 +150,47 @@ class GameLibrary {
         let id = String(folderName.prefix(36))
 
         let metadata = GameMetadata.load(for: id)
-        let title = metadata.customTitle ?? iniTitle
+        // Title priority: user's customTitle > import-time baseTitle
+        // (JGP manifest name) > Game.ini title. The `engineTitle`
+        // subtitle on the library card only surfaces when the user
+        // has explicitly set a `customTitle` that diverges from the
+        // engine's Game.ini title - so we can show both their
+        // chosen name and what the game calls itself. JGP imports
+        // deliberately use the manifest as the authoritative title
+        // and don't show a subtitle; JoiPlay's chosen name is THE
+        // name, and surfacing Game.ini alongside would just clutter
+        // the card with a near-duplicate.
+        let baseTitle = metadata.baseTitle ?? iniTitle
+        let title = metadata.customTitle ?? baseTitle
         let artworkPath = metadata.customArtworkPath(for: id) ?? defaultArtwork
-        let originalTitle = metadata.customTitle != nil ? iniTitle : nil
+        let engineTitle: String? = {
+            guard metadata.customTitle != nil else { return nil }
+            return title != iniTitle ? iniTitle : nil
+        }()
 
         return GameEntry(
             id: id,
             path: url.path,
             title: title,
             artworkPath: artworkPath,
-            originalTitle: originalTitle,
+            engineTitle: engineTitle,
             lastPlayed: metadata.lastPlayed
         )
+    }
+
+    /// Comparator used to decide whether to surface the engine's
+    /// Game.ini title on a library card. Strips diacritics and
+    /// case-folds so cosmetically-equivalent names ("Pokemon
+    /// Reborn" vs "Pokémon Reborn") don't produce a nearly-
+    /// duplicate subtitle. Trailing/leading whitespace is also
+    /// ignored so a stray newline in Game.ini doesn't trip it.
+    nonisolated private static func titlesMeaningfullyDiffer(_ a: String, _ b: String) -> Bool {
+        let folded: (String) -> String = { raw in
+            raw.trimmingCharacters(in: .whitespacesAndNewlines)
+                .folding(options: [.diacriticInsensitive, .caseInsensitive],
+                         locale: Locale(identifier: "en_US_POSIX"))
+        }
+        return folded(a) != folded(b)
     }
 
 
@@ -311,7 +340,7 @@ class GameLibrary {
                     path: lib.games[idx].path,
                     title: lib.games[idx].title,
                     artworkPath: artworkPath,
-                    originalTitle: lib.games[idx].originalTitle,
+                    engineTitle: lib.games[idx].engineTitle,
                     lastPlayed: lib.games[idx].lastPlayed,
                     status: lib.games[idx].status
                 )
@@ -385,6 +414,7 @@ class GameLibrary {
         }
 
         if isImportCancelled(importID) { throw ImportCancelled() }
+        Self.detectAndPersistModernRuby(in: destURL)
         GameLibrary.createMetadata(for: importID)
         committed = true
     }
@@ -550,6 +580,18 @@ class GameLibrary {
         guard !isImportCancelled(importID) else { throw ImportCancelled() }
 
         let gameRoot = try GameLibrary.findGameRoot(in: tmpDir)
+
+        // JGP post-processing: if the archive was a JoiPlay .jgp,
+        // parse manifest/configuration/gamepad, reject unsupported
+        // runtimes, strip the JGP-specific files from the game
+        // folder so they don't ship next to the engine files, and
+        // keep a `JgpImport` bundle so we can seed metadata +
+        // settings after the final move. Regular .zip imports skip
+        // this branch entirely.
+        let jgpBundle: Jgp.Bundle? = sourceURL.pathExtension.lowercased() == "jgp"
+            ? try Self.preprocessJgp(at: gameRoot)
+            : nil
+
         let destURL = destinationURL(for: importID, title: title)
         try fm.moveItem(at: gameRoot, to: destURL)
 
@@ -561,14 +603,144 @@ class GameLibrary {
         }
 
         if isImportCancelled(importID) { throw ImportCancelled() }
-        GameLibrary.createMetadata(for: importID)
+        if let bundle = jgpBundle {
+            Self.finalizeJgpImport(
+                importID: importID,
+                destURL: destURL,
+                bundle: bundle
+            )
+        } else {
+            GameLibrary.createMetadata(for: importID)
+        }
         committed = true
+    }
+
+    /// JoiPlay .jgp post-extract step. Parses the three JSON
+    /// sidecars, rejects unsupported runtimes, and removes the
+    /// sidecars + icon from the game folder so the runtime sees a
+    /// clean RGSS tree. The returned `Bundle` carries everything
+    /// we need to seed metadata + settings once the folder is
+    /// moved to its final destination.
+    nonisolated private static func preprocessJgp(at gameRoot: URL) throws -> Jgp.Bundle {
+        guard let bundle = Jgp.parseBundle(at: gameRoot) else {
+            throw GameImportValidator.ImportError.invalidJgpManifest
+        }
+
+        switch bundle.manifest.type {
+        case .rpgmxp, .rpgmvx, .rpgmvxace, .mkxpZ:
+            break
+        case .unsupported(let raw):
+            throw GameImportValidator.ImportError.unsupportedRuntime(
+                "This JoiPlay archive uses '\(raw)' which isn't supported. "
+                + "Only RPG Maker XP, VX, VX Ace, and mkxp-z games are currently supported."
+            )
+        }
+
+        let fm = FileManager.default
+        for name in ["manifest.json", "configuration.json", "gamepad.json"] {
+            try? fm.removeItem(at: gameRoot.appendingPathComponent(name))
+        }
+        if let iconRel = bundle.manifest.icon, !iconRel.isEmpty {
+            try? fm.removeItem(at: gameRoot.appendingPathComponent(iconRel))
+        }
+
+        return bundle
+    }
+
+    /// Seed metadata + per-game settings + per-game control layout
+    /// for a freshly-imported JGP. Runs on the import thread after
+    /// the game folder is at its permanent destination so all
+    /// side-effect paths (game_settings.json, mkxp.json, metadata
+    /// sidecar, UserDefaults layout key) use the final locations.
+    nonisolated private static func finalizeJgpImport(
+        importID: String,
+        destURL: URL,
+        bundle: Jgp.Bundle
+    ) {
+        // Seed engine settings from the bundled configuration. The
+        // cheats flag is a separate sidecar (configuration.json in
+        // our GameSettings namespace) because it outlives the
+        // mkxp.json regeneration on settings-reset.
+        var settings = bundle.configuration?.toGameSettings() ?? GameSettings()
+
+        // Ruby-syntax detection. JoiPlay's "mkxp-z" runtime
+        // label plus Reborn-style bootstrap games ship actual
+        // Ruby 3 source, so force useModernRuby for those. For
+        // other runtime types we scan `.rb` files for Ruby 3
+        // markers as a fallback - catches PE v20+ games that
+        // still tag themselves as rpgmxp but have been ported
+        // to the modern Essentials codebase.
+        if bundle.manifest.type == .mkxpZ {
+            settings.useModernRuby = true
+        } else if GameSettings.detectModernRubyScripts(in: destURL) {
+            settings.useModernRuby = true
+        }
+
+        settings.applyToConfig(in: destURL)
+        settings.save(to: destURL)
+        if let cheats = bundle.configuration?.cheats {
+            GameSettings.saveCheats(cheats, to: destURL)
+        }
+
+        // Seed the per-game control layout from the JGP gamepad
+        // hints. Users can still re-arrange in the player toolbar
+        // afterwards and their edits override this seed.
+        if let gamepad = bundle.gamepad {
+            let seed = gamepad.toSeedLayout()
+            ControlsLayout.writeInitialPerGameLayout(
+                gameID: importID,
+                dpadCenter: seed.dpadCenter,
+                dpadSize: seed.dpadSize,
+                buttons: seed.buttons
+            )
+        }
+
+        // Metadata carries manifest fields and the JGP icon (if
+        // present) as custom artwork so the library card shows
+        // JoiPlay's canonical branding for the game. The manifest
+        // name becomes the BASE title (not a custom override) -
+        // the library resolves title as customTitle ?? baseTitle ??
+        // iniTitle, so the user still sees the manifest name first
+        // but can type their own customTitle on top if desired,
+        // and Game.ini's title stays available as the final
+        // fallback when there's no manifest.
+        var metadata = GameMetadata()
+        metadata.dateAdded = Date()
+        metadata.baseTitle = bundle.manifest.name
+        metadata.manifestId = bundle.manifest.id
+        metadata.manifestVersion = bundle.manifest.version
+        metadata.manifestDescription = bundle.manifest.description
+
+        if let iconData = bundle.iconData,
+           let image = UIImage(data: iconData),
+           let filename = GameMetadata.saveImage(image, as: "artwork", for: importID) {
+            metadata.customArtworkFilename = filename
+        }
+
+        metadata.save(for: importID)
     }
 
     nonisolated private static func createMetadata(for gameId: String) {
         var metadata = GameMetadata()
         metadata.dateAdded = Date()
         metadata.save(for: gameId)
+    }
+
+    /// Scans the freshly-extracted game folder for Ruby 3 syntax
+    /// markers and persists `useModernRuby: true` + updates
+    /// mkxp.json if any are found. A no-op for classical PE
+    /// fangames written in Ruby 1.8 - the heuristic only fires on
+    /// games that actually ship Ruby 3 source (Reborn 19.5+,
+    /// PE v20+, anything built on modern Essentials). JGP imports
+    /// have their own detection path in `finalizeJgpImport` that
+    /// also honors the manifest's runtime hint; this helper covers
+    /// the plain .zip / folder import path.
+    nonisolated private static func detectAndPersistModernRuby(in gameDirectory: URL) {
+        guard GameSettings.detectModernRubyScripts(in: gameDirectory) else { return }
+        var settings = GameSettings.load(from: gameDirectory)
+        settings.useModernRuby = true
+        settings.applyToConfig(in: gameDirectory)
+        settings.save(to: gameDirectory)
     }
 
 

--- a/ios/Empo/src/Library/GameMetadata.swift
+++ b/ios/Empo/src/Library/GameMetadata.swift
@@ -10,6 +10,23 @@ struct GameMetadata: Codable {
     var customArtworkFilename: String?  // e.g. "artwork.jpg", stored in Metadata/{id}/
     var customBannerFilename: String?   // e.g. "banner.jpg", stored in Metadata/{id}/
 
+    // Title sourced from the import, not from a user edit. For JGP
+    // imports this comes from the manifest's `name` field, which
+    // the packager chose on purpose (often cleaner than what
+    // Game.ini happens to say). The library uses this as the base
+    // title, but users can still override it with `customTitle`
+    // afterwards. nil for non-JGP imports, which fall back to
+    // Game.ini's title as the base.
+    var baseTitle: String?
+
+    // JoiPlay JGP manifest fields carried over at import time. Shared
+    // across all imports of the same JGP so we can detect duplicates
+    // when the same archive is imported twice and offer the user a
+    // replace/duplicate/cancel choice.
+    var manifestId: String?
+    var manifestVersion: String?
+    var manifestDescription: String?
+
 
     private static var metadataDirectory: URL {
         FileManager.default
@@ -128,6 +145,26 @@ struct GameMetadata: Codable {
     static func removeImage(named filename: String, for gameId: String) {
         let url = mediaDirectory(for: gameId).appendingPathComponent(filename)
         try? FileManager.default.removeItem(at: url)
+    }
+
+
+    /// Returns any game IDs whose metadata has the given JGP manifest id.
+    /// Used to detect when a user imports the same JGP archive twice so
+    /// the import flow can offer to replace the existing entry or add a
+    /// second copy.
+    static func gameIDs(withManifestId manifestId: String) -> [String] {
+        let fm = FileManager.default
+        let dir = metadataDirectory
+        guard let entries = try? fm.contentsOfDirectory(atPath: dir.path) else {
+            return []
+        }
+        return entries.compactMap { name -> String? in
+            guard name.hasSuffix(".json") else { return nil }
+            let gameId = String(name.dropLast(".json".count))
+            let metadata = load(for: gameId)
+            guard metadata.manifestId == manifestId else { return nil }
+            return gameId
+        }
     }
 
 

--- a/ios/Empo/src/Library/GameSettings.swift
+++ b/ios/Empo/src/Library/GameSettings.swift
@@ -78,6 +78,15 @@ struct GameSettings: Codable, Equatable {
 
     // Engine
     var postloadScripts: Bool?         // execute postload scripts for common fixes
+    // Nil = default (Ruby 1.8 compat for max PE fangame compatibility).
+    // True = disable syntaxTransform so the engine runs pure Ruby 3.
+    // Needed for games that ship Ruby-3-era scripts (keyword-arg
+    // hash shorthand, numbered block params, etc.) - notably Pokemon
+    // Reborn 19.5+, PE v20+, and any game packaged for the mkxp-z
+    // runtime. Detected automatically during JGP import by scanning
+    // .rb scripts for Ruby-3-only syntax, but users can also flip
+    // this manually per game if the heuristic misses.
+    var useModernRuby: Bool?
 
 
     private static let settingsFilename = "game_settings.json"
@@ -125,6 +134,72 @@ struct GameSettings: Codable, Equatable {
         if let data = try? JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys]) {
             try? data.write(to: url, options: .atomic)
         }
+    }
+
+
+    /// Scans a freshly-imported game folder for Ruby 3-only syntax
+    /// markers and returns true if any are found. Used by the
+    /// import pipeline to set `useModernRuby` so the engine runs
+    /// without the Ruby 1.8 compat transform for games that ship
+    /// modern Ruby source (Reborn 19.5+, PE v20+, mkxp-z JGPs).
+    ///
+    /// Heuristic-only: looks for keyword-arg shorthand
+    /// (`id: -1,`, `foo: "bar",`) anywhere inside `.rb` files at
+    /// the game root or `Scripts/` subfolder. The 1.8-era syntax
+    /// for the same idea is `:id => -1`, so the `key: value,`
+    /// form is a strong Ruby-3 signal. False positives on comments
+    /// or strings containing that pattern are possible but rare
+    /// and have no ill effect - disabling the transform on a 1.8
+    /// game still runs it as Ruby 3, which works for everything
+    /// except legacy constructs the transform would have rewritten
+    /// (and we can flip the setting manually afterwards).
+    static func detectModernRubyScripts(in gameDirectory: URL) -> Bool {
+        let fm = FileManager.default
+
+        // Search depth is capped by the enumerator's defaults.
+        // Stop at the first positive match to keep big fangames
+        // from scanning thousands of files on import.
+        let candidates = [
+            gameDirectory,
+            gameDirectory.appendingPathComponent("Scripts"),
+            gameDirectory.appendingPathComponent("Data"),
+        ]
+
+        // Ruby 3 keyword-arg shorthand inside method calls. A word
+        // followed by a colon and a literal value or variable, with
+        // no `=>` rocket before it. Excludes YAML-style ":foo"
+        // symbols by requiring the identifier BEFORE the colon.
+        let modernRegex = try? NSRegularExpression(
+            pattern: "\\n\\s*[a-z_][a-zA-Z0-9_]*:\\s+(-?\\d|\"|\\[|\\{|true|false|nil|:)",
+            options: []
+        )
+        guard let regex = modernRegex else { return false }
+
+        for root in candidates {
+            guard fm.fileExists(atPath: root.path),
+                  let enumerator = fm.enumerator(at: root,
+                      includingPropertiesForKeys: nil,
+                      options: [.skipsHiddenFiles])
+            else { continue }
+
+            var filesScanned = 0
+            for case let url as URL in enumerator {
+                if url.pathExtension.lowercased() != "rb" { continue }
+                filesScanned += 1
+                // Hard cap so a pathological game tree can't stall
+                // the import pipeline.
+                if filesScanned > 200 { break }
+
+                guard let text = try? String(contentsOf: url, encoding: .utf8)
+                else { continue }
+
+                let range = NSRange(text.startIndex..., in: text)
+                if regex.firstMatch(in: text, options: [], range: range) != nil {
+                    return true
+                }
+            }
+        }
+        return false
     }
 
 
@@ -188,11 +263,20 @@ struct GameSettings: Codable, Equatable {
             config = parsed
         }
 
-        // Always enable Ruby 1.8 compatibility syntax transform for RGSS1/2
-        // games. Without this the engine runs Ruby 3.1 strict mode and rejects
-        // 1.8-era syntax (`when X:`, `retry` outside rescue, unparenthesized
-        // method calls with spaces, etc.) at parse time.
-        if config["syntaxTransform"] == nil {
+        // Ruby compatibility mode. Most PE fangames are written in
+        // Ruby 1.8 syntax and need `syntaxTransform: 2` so the
+        // engine translates old forms (`when X:`, unparenthesized
+        // method chains, legacy hash rockets, etc) before Ruby 3
+        // parses them. Games targeting the modern `mkxp-z` runtime
+        // - Reborn 19.5+, PE v20+, anything packaged as an mkxp-z
+        // JGP - ship actual Ruby 3 source (keyword-arg shorthand
+        // `id: -1`, `foo: "bar"`) which the 1.8 transform would
+        // mis-parse. For those we explicitly disable the transform
+        // by writing `syntaxTransform: 0`. The import-time detector
+        // flips useModernRuby when it finds Ruby-3-only syntax.
+        if let modern = useModernRuby, modern {
+            config["syntaxTransform"] = 0
+        } else if config["syntaxTransform"] == nil {
             config["syntaxTransform"] = 2
         }
 

--- a/ios/Empo/src/Library/Jgp.swift
+++ b/ios/Empo/src/Library/Jgp.swift
@@ -1,0 +1,374 @@
+import Foundation
+import UIKit
+
+
+/// JoiPlay archive runtime type. Any value outside the first-class
+/// cases is surfaced as `.unsupported(raw:)` so we can display a
+/// precise error. The supported set covers every RGSS version our
+/// mkxp-z engine handles (XP = RGSS1, VX = RGSS2, VX Ace = RGSS3)
+/// plus the explicit "mkxp-z" label JoiPlay uses for games that
+/// were pre-packaged against the mkxp-z engine with Ruby 3 - that
+/// label matches our runtime exactly so we accept it too.
+/// JoiPlay also issues archives for Ren'Py, TyranoBuilder, HTML,
+/// Flash, and MZ/MV - we have no runtime for those and reject them
+/// with a per-type explanation during import.
+enum JgpRuntime: Codable, Equatable {
+    case rpgmxp                 // RPG Maker XP  (RGSS1)
+    case rpgmvx                 // RPG Maker VX  (RGSS2)
+    case rpgmvxace              // RPG Maker VX Ace (RGSS3)
+    case mkxpZ                  // Prebuilt for mkxp-z with Ruby 3
+    case unsupported(raw: String)
+
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        switch raw {
+        case "rpgmxp":    self = .rpgmxp
+        case "rpgmvx":    self = .rpgmvx
+        case "rpgmvxace": self = .rpgmvxace
+        case "mkxp-z":    self = .mkxpZ
+        default:          self = .unsupported(raw: raw)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        switch self {
+        case .rpgmxp:    try c.encode("rpgmxp")
+        case .rpgmvx:    try c.encode("rpgmvx")
+        case .rpgmvxace: try c.encode("rpgmvxace")
+        case .mkxpZ:     try c.encode("mkxp-z")
+        case .unsupported(let r): try c.encode(r)
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .rpgmxp:    "RPG Maker XP"
+        case .rpgmvx:    "RPG Maker VX"
+        case .rpgmvxace: "RPG Maker VX Ace"
+        case .mkxpZ:     "mkxp-z"
+        case .unsupported(let r): r
+        }
+    }
+}
+
+
+/// `manifest.json` - identifies the game and its runtime.
+struct JgpManifest: Codable {
+    let id: String
+    let name: String
+    let version: String?
+    let description: String?
+    let icon: String?
+    let executable: String?
+    let type: JgpRuntime
+}
+
+
+/// `configuration.json` - engine and renderer preferences bundled by the
+/// game developer. All fields are optional; anything unsupported on our
+/// platform is ignored.
+struct JgpConfiguration: Codable {
+    // Shared
+    let cheats: Bool?
+
+    // RPG Maker subset
+    let windowSize: String?      // "640x480"
+    let fontScale: String?       // stored as string in JGP; parsed to Double
+    let speedUp: String?         // "1", "2", "3" ...
+    let smoothScaling: Bool?
+    let vsync: Bool?
+    let frameSkip: Bool?
+    let solidFonts: Bool?
+    let pathCache: Bool?
+    let enablePostloadScripts: Bool?
+    let customFont: String?
+}
+
+
+/// `gamepad.json` - touch control layout hints. Values are Android key codes.
+struct JgpGamepad: Codable {
+    let btnOpacity: Int?
+    let btnScale: Int?
+    let aKeyCode: Int?
+    let bKeyCode: Int?
+    let cKeyCode: Int?
+    let xKeyCode: Int?
+    let yKeyCode: Int?
+    let zKeyCode: Int?
+    let lKeyCode: Int?
+    let rKeyCode: Int?
+}
+
+
+enum Jgp {
+    /// Entry-point bundle of parsed JGP files.
+    struct Bundle {
+        let manifest: JgpManifest
+        let configuration: JgpConfiguration?
+        let gamepad: JgpGamepad?
+        let iconData: Data?
+        /// Directory containing the game itself (after removing JGP-specific files).
+        let gameRoot: URL
+    }
+
+
+    /// Parse the three JSON files out of an already-extracted JGP directory
+    /// and resolve the icon data. Returns nil if manifest.json is missing or
+    /// unreadable. Other files are optional.
+    // Callers are responsible for removing the JGP-specific files
+    // (manifest.json, configuration.json, gamepad.json, icon) from the
+    // final game directory after import if they don't want them shipped
+    // alongside the engine files.
+    static func parseBundle(at root: URL) -> Bundle? {
+        let manifestURL = root.appendingPathComponent("manifest.json")
+        guard let manifestRaw = try? String(contentsOf: manifestURL, encoding: .utf8),
+              let manifest = decodeWithComments(JgpManifest.self, from: manifestRaw) else {
+            return nil
+        }
+
+        let configuration: JgpConfiguration? = {
+            let url = root.appendingPathComponent("configuration.json")
+            guard let raw = try? String(contentsOf: url, encoding: .utf8) else { return nil }
+            return decodeWithComments(JgpConfiguration.self, from: raw)
+        }()
+
+        let gamepad: JgpGamepad? = {
+            let url = root.appendingPathComponent("gamepad.json")
+            guard let raw = try? String(contentsOf: url, encoding: .utf8) else { return nil }
+            return decodeWithComments(JgpGamepad.self, from: raw)
+        }()
+
+        let iconData: Data? = {
+            guard let iconPath = manifest.icon, !iconPath.isEmpty else { return nil }
+            let iconURL = root.appendingPathComponent(iconPath)
+            return try? Data(contentsOf: iconURL)
+        }()
+
+        return Bundle(
+            manifest: manifest,
+            configuration: configuration,
+            gamepad: gamepad,
+            iconData: iconData,
+            gameRoot: root
+        )
+    }
+
+
+    /// JGP uses the same `//` comment tolerance as mkxp.json. Strip comments
+    /// before handing to `JSONDecoder`.
+    private static func decodeWithComments<T: Decodable>(_ type: T.Type, from raw: String) -> T? {
+        let cleaned = stripLineComments(raw)
+        guard let data = cleaned.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(T.self, from: data)
+    }
+
+    private static func stripLineComments(_ raw: String) -> String {
+        var out = ""
+        var inString = false
+        var escaped = false
+        var i = raw.startIndex
+        while i < raw.endIndex {
+            let c = raw[i]
+            if escaped {
+                out.append(c)
+                escaped = false
+                i = raw.index(after: i)
+                continue
+            }
+            if c == "\\" && inString {
+                out.append(c)
+                escaped = true
+                i = raw.index(after: i)
+                continue
+            }
+            if c == "\"" {
+                inString.toggle()
+                out.append(c)
+                i = raw.index(after: i)
+                continue
+            }
+            if !inString && c == "/" {
+                let next = raw.index(after: i)
+                if next < raw.endIndex && raw[next] == "/" {
+                    while i < raw.endIndex && raw[i] != "\n" {
+                        i = raw.index(after: i)
+                    }
+                    continue
+                }
+            }
+            out.append(c)
+            i = raw.index(after: i)
+        }
+        return out
+    }
+}
+
+
+// MARK: - Configuration -> GameSettings mapping
+
+
+extension JgpConfiguration {
+    /// Translate a JGP `configuration.json` into our per-game `GameSettings`.
+    /// Anything unsupported on iOS is ignored (`renpy_*`, `useRuby18`, etc.).
+    func toGameSettings() -> GameSettings {
+        var s = GameSettings()
+        s.smoothScaling = smoothScaling
+        s.vsync = vsync
+        s.frameSkip = frameSkip
+        s.solidFonts = solidFonts
+        s.pathCache = pathCache
+        s.postloadScripts = enablePostloadScripts
+
+        if let scaleStr = fontScale, let scale = Double(scaleStr) {
+            s.fontScale = scale
+        }
+        if let speedStr = speedUp, let speed = Int(speedStr), speed > 1 {
+            s.speedMultiplier = speed
+        }
+        if let size = windowSize {
+            let parts = size.lowercased().split(separator: "x").compactMap { Int($0) }
+            if parts.count == 2, parts[0] > 0, parts[1] > 0 {
+                s.resolution = ResolutionPreset(width: parts[0], height: parts[1])
+            }
+        }
+        return s
+    }
+}
+
+
+// MARK: - Gamepad mapping
+
+
+extension JgpGamepad {
+    /// Installed-layout shape the import pipeline hands to
+    /// `ControlsLayout.writeInitialPerGameLayout`. We don't touch
+    /// the private `PersistedLayout` type here - the pipeline
+    /// expands this into a persisted snapshot for the game.
+    struct SeedLayout {
+        let dpadCenter: CGPoint
+        let dpadSize: CGFloat
+        let buttons: [ButtonModel]
+    }
+
+    /// Map the JGP Android key codes to an initial touch-control
+    /// layout snapshot. Unknown key codes fall back to the RGSS
+    /// default for that slot so the game is always playable even
+    /// with an incomplete JGP gamepad.json.
+    func toSeedLayout() -> SeedLayout {
+        struct Slot {
+            let key: Int?
+            let defaultScancode: Int32
+            let label: String
+            let relativeCenter: CGPoint
+            let size: CGFloat
+        }
+
+        let slots: [Slot] = [
+            Slot(key: aKeyCode, defaultScancode: Int32(MKXP_SCANCODE_RETURN),
+                 label: "A", relativeCenter: CGPoint(x: 0.85, y: 0.78), size: 60),
+            Slot(key: bKeyCode, defaultScancode: Int32(MKXP_SCANCODE_ESCAPE),
+                 label: "B", relativeCenter: CGPoint(x: 0.72, y: 0.70), size: 56),
+            Slot(key: xKeyCode, defaultScancode: Int32(MKXP_SCANCODE_LSHIFT),
+                 label: "X", relativeCenter: CGPoint(x: 0.62, y: 0.82), size: 50),
+            Slot(key: yKeyCode, defaultScancode: Int32(MKXP_SCANCODE_LCTRL),
+                 label: "Y", relativeCenter: CGPoint(x: 0.72, y: 0.62), size: 44),
+        ]
+
+        let buttons = slots.map { slot -> ButtonModel in
+            let scancode = slot.key.flatMap(androidKeyCodeToScancode) ?? slot.defaultScancode
+            return ButtonModel(
+                label: slot.label,
+                scancode: scancode,
+                relativeCenter: slot.relativeCenter,
+                size: slot.size
+            )
+        }
+
+        return SeedLayout(
+            dpadCenter: ControlsLayout.defaultDPadCenter,
+            dpadSize: ControlsLayout.defaultDPadSize,
+            buttons: buttons
+        )
+    }
+
+
+    /// Android `KeyEvent` constant -> mkxp scancode. Returns nil for key
+    /// codes we don't have an equivalent for.
+    /// See: https://developer.android.com/reference/android/view/KeyEvent
+    private func androidKeyCodeToScancode(_ code: Int) -> Int32? {
+        switch code {
+        // Letters (Android KEYCODE_A=29 ... KEYCODE_Z=54)
+        case 29: return Int32(MKXP_SCANCODE_A)
+        case 30: return Int32(MKXP_SCANCODE_B)
+        case 31: return Int32(MKXP_SCANCODE_C)
+        case 32: return Int32(MKXP_SCANCODE_D)
+        case 33: return Int32(MKXP_SCANCODE_E)
+        case 34: return Int32(MKXP_SCANCODE_F)
+        case 35: return Int32(MKXP_SCANCODE_G)
+        case 36: return Int32(MKXP_SCANCODE_H)
+        case 37: return Int32(MKXP_SCANCODE_I)
+        case 38: return Int32(MKXP_SCANCODE_J)
+        case 39: return Int32(MKXP_SCANCODE_K)
+        case 40: return Int32(MKXP_SCANCODE_L)
+        case 41: return Int32(MKXP_SCANCODE_M)
+        case 42: return Int32(MKXP_SCANCODE_N)
+        case 43: return Int32(MKXP_SCANCODE_O)
+        case 44: return Int32(MKXP_SCANCODE_P)
+        case 45: return Int32(MKXP_SCANCODE_Q)
+        case 46: return Int32(MKXP_SCANCODE_R)
+        case 47: return Int32(MKXP_SCANCODE_S)
+        case 48: return Int32(MKXP_SCANCODE_T)
+        case 49: return Int32(MKXP_SCANCODE_U)
+        case 50: return Int32(MKXP_SCANCODE_V)
+        case 51: return Int32(MKXP_SCANCODE_W)
+        case 52: return Int32(MKXP_SCANCODE_X)
+        case 53: return Int32(MKXP_SCANCODE_Y)
+        case 54: return Int32(MKXP_SCANCODE_Z)
+
+        // Arrows (KEYCODE_DPAD_*)
+        case 19: return Int32(MKXP_SCANCODE_UP)
+        case 20: return Int32(MKXP_SCANCODE_DOWN)
+        case 21: return Int32(MKXP_SCANCODE_LEFT)
+        case 22: return Int32(MKXP_SCANCODE_RIGHT)
+
+        // Common controls. mkxp-ios only models left-variants of modifiers.
+        case 59, 60: return Int32(MKXP_SCANCODE_LSHIFT)   // SHIFT_LEFT/RIGHT
+        case 66:     return Int32(MKXP_SCANCODE_RETURN)   // ENTER
+        case 111:    return Int32(MKXP_SCANCODE_ESCAPE)   // ESCAPE
+        case 62:     return Int32(MKXP_SCANCODE_SPACE)    // SPACE
+        case 113, 114: return Int32(MKXP_SCANCODE_LCTRL)  // CTRL_LEFT/RIGHT
+        case 57, 58:   return Int32(MKXP_SCANCODE_LALT)   // ALT_LEFT/RIGHT
+        case 61: return Int32(MKXP_SCANCODE_TAB)
+        case 67: return Int32(MKXP_SCANCODE_BACKSPACE)
+
+        // Digits 0-9 (top row)
+        case 7:  return Int32(MKXP_SCANCODE_0)
+        case 8:  return Int32(MKXP_SCANCODE_1)
+        case 9:  return Int32(MKXP_SCANCODE_2)
+        case 10: return Int32(MKXP_SCANCODE_3)
+        case 11: return Int32(MKXP_SCANCODE_4)
+        case 12: return Int32(MKXP_SCANCODE_5)
+        case 13: return Int32(MKXP_SCANCODE_6)
+        case 14: return Int32(MKXP_SCANCODE_7)
+        case 15: return Int32(MKXP_SCANCODE_8)
+        case 16: return Int32(MKXP_SCANCODE_9)
+
+        // F-keys
+        case 131: return Int32(MKXP_SCANCODE_F1)
+        case 132: return Int32(MKXP_SCANCODE_F2)
+        case 133: return Int32(MKXP_SCANCODE_F3)
+        case 134: return Int32(MKXP_SCANCODE_F4)
+        case 135: return Int32(MKXP_SCANCODE_F5)
+        case 136: return Int32(MKXP_SCANCODE_F6)
+        case 137: return Int32(MKXP_SCANCODE_F7)
+        case 138: return Int32(MKXP_SCANCODE_F8)
+        case 139: return Int32(MKXP_SCANCODE_F9)
+        case 140: return Int32(MKXP_SCANCODE_F10)
+        case 141: return Int32(MKXP_SCANCODE_F11)
+        case 142: return Int32(MKXP_SCANCODE_F12)
+
+        default: return nil
+        }
+    }
+}

--- a/ios/Empo/src/Player/ControlsLayout.swift
+++ b/ios/Empo/src/Player/ControlsLayout.swift
@@ -112,6 +112,32 @@ class ControlsLayout {
     }
 
 
+    /// Seed an initial layout for a game ID that isn't currently
+    /// active. Used by the JGP import path so the game starts with
+    /// the layout bundled in the archive rather than our defaults.
+    /// Overwrites any existing persisted layout, so only call during
+    /// first import. Marked `nonisolated` because it only writes to
+    /// UserDefaults and touches no instance state, which lets the
+    /// import pipeline (running on a background Task) seed layouts
+    /// without hopping to the main actor.
+    nonisolated static func writeInitialPerGameLayout(
+        gameID: String,
+        dpadCenter: CGPoint,
+        dpadSize: CGFloat,
+        dpadOpacity: Double = 1.0,
+        buttons: [ButtonModel]
+    ) {
+        let layout = PersistedLayout(
+            dpad: .init(rx: dpadCenter.x, ry: dpadCenter.y,
+                        size: dpadSize, opacity: dpadOpacity),
+            buttons: buttons
+        )
+        guard let data = try? JSONEncoder().encode(layout) else { return }
+        UserDefaults.standard.set(data,
+            forKey: DefaultsKey.controlsLayout(gameID: gameID))
+    }
+
+
     static let defaultDPadCenter = CGPoint(x: 0.13, y: 0.72)
     static let defaultDPadSize: CGFloat = 140
     static let defaultButtons: [ButtonModel] = [


### PR DESCRIPTION
## Summary

Ships JoiPlay .jgp archive import + all the compat shims needed to boot Pokemon Reborn (and similar Ruby-3 era fangames).

### Engine / mkxp-z submodule
- **Viewport size-cache bug**: guarded `SDL_SetWindowSize` in the REQUEST_WINRESIZE event handler with `#if !TARGET_OS_IPHONE`. Without the guard, `Graphics.resize_screen(512, 384)` leaves SDL's cached logical size at 512x384, and the next session reads that stale value and renders a smaller-than-screen viewport.
- **\$joiplay = true**: routes PE fangames through JoiPlay's code paths at boot. Reborn's `internal_se_play` and similar branches use our supported APIs instead of the unimplemented positional-audio extension.
- **MKXP.plugin_version**: reports 99999 so Reborn's bootstrap version check passes.
- **MKXP.apply_overrides**: exposes the already-integrated script text-patcher to Ruby. Reborn's ScriptLoader pipes each section through this before eval, expecting the JoiPlay-style JSON rule rewriter.
- **Require fallback + socket stubs**: intercepts LoadError for network stdlib/gems (socket, net/http, openssl, discord, poke-api-v2, etc.) and returns stub classes so a single `require 'socket'` at the top of a bootstrap script doesn't crash the eval.

### iOS / Swift
- **JGP import**: `Jgp.swift` parses manifest.json / configuration.json / gamepad.json from JoiPlay-style archives. Import pipeline seeds engine settings, control-layout buttons, and metadata (title/icon/manifestId) from the archive. Rejects unsupported runtimes (renpy/tyrano/html/flash/etc) with a per-type message.
- **Ruby-3 detection heuristic**: `GameSettings.detectModernRubyScripts` scans the game folder for Ruby-3-only syntax markers (keyword-arg shorthand) and sets `useModernRuby: true` so the engine turns off `syntaxTransform=2` (Ruby 1.8 compat) on games that ship modern Ruby (Reborn 19.5+, PE v20+).
- **baseTitle vs customTitle**: `GameMetadata.baseTitle` captures the JoiPlay manifest name as the library's default title (non-overriding). Renamed `GameEntry.originalTitle` -> `engineTitle` to reflect what it actually is (the Game.ini title shown as secondary).
- **UTType registration**: `.jgp` registered as a zip subtype via CFBundleDocumentTypes / UTExportedTypeDeclarations so Files.app + the document picker accept it.

### Notes
- A second viewport-letterbox regression on second-launch-of-Reborn remains; filed in TODO.md with investigation notes. C++ diagnostics show the engine publishes identical gameRect values in both sessions so the issue is likely in the Metal-layer / CALayer path.
- Per-game keyboard bridging (iOS on-screen keyboard -> SDL_TEXTINPUT) also filed as a follow-up; today users can toggle "Use Keyboard: Off" in Reborn's in-game Options to route name-entry through the on-screen picker.

## How to test
1. Install a JGP (example: Pokemon Reborn AllGen) via Import.
2. Confirm it boots past the version-check prompt to the title screen.
3. Confirm the library card shows the manifest name.