### PR TITLE
fix: pokemon reborn second-session viewport regression

### DIFF
--- a/ios/Empo/src/Library/Jgp.swift
+++ b/ios/Empo/src/Library/Jgp.swift
@@ -218,7 +218,15 @@ extension JgpConfiguration {
         s.frameSkip = frameSkip
         s.solidFonts = solidFonts
         s.pathCache = pathCache
-        s.postloadScripts = enablePostloadScripts
+        // Intentionally NOT mapping `enablePostloadScripts` onto our
+        // `postloadScripts` setting. JoiPlay's flag controls its own
+        // JoiPlay-specific postload hooks; ours controls the engine's
+        // compat-shim pipeline (NilClass safe-stubs, $joiplay signal,
+        // MKXP.plugin_version, Graphics.poke_* aliases, Pokemon-
+        // specific session-reset hooks, etc.). JGPs that set
+        // `enablePostloadScripts: false` (notably Reborn) still
+        // depend on our compat shims to boot, so leave our postload
+        // path enabled by default.
 
         if let scaleStr = fontScale, let scale = Double(scaleStr) {
             s.fontScale = scale


### PR DESCRIPTION
## Summary

Fixes Pokemon Reborn (and likely other PE fangames) rendering at a shrunken viewport with black bars on session 2+.

### Root cause

Reborn's \`pbSetUpSystem\` wraps its screen-setup code in \`if defined?(\$game_system)\`, intended to be nil on first launch and truthy on re-launches (desktop assumption: each launch gets a fresh Ruby VM). Our engine reuses the Ruby VM across game sessions (Ruby 3's \`ruby_init/cleanup\` doesn't cycle cleanly), so the global's name remains in Ruby's symbol table even after we reset its value to nil, and \`defined?\` returns \`"global-variable"\`. Reborn then takes the "already up" branch, skips \`pbSetResizeFactor\`, and the engine stays at 640x480 default while the game's sprites expect 512x384. The visible result is an 80%-width viewport with black bars on the right and below.

### Fix

New postload \`pokemon_session_reset.rb\` spawns a one-shot Thread that polls for \`pbSetResizeFactor\` + \`\$Settings\` availability, then calls \`pbSetResizeFactor(\$Settings.screensize)\` directly, bypassing the \`defined?\` guard. On session 1 it's an idempotent no-op (the game already called it). On session 2+ it performs the missed re-init.

Also fixes a JGP import bug: \`configuration.json\`'s \`enablePostloadScripts\` was being mapped onto our \`postloadScripts\` engine setting. JoiPlay's flag controls JoiPlay's own postloads while ours controls our compat-shim pipeline. Reborn's JGP sets the flag false, which on our engine disabled all our compat shims (including this viewport fix, \`\$joiplay\`, \`MKXP.plugin_version\`, etc). Removed the mapping.

### How to test
1. Launch any game (e.g. Uranium), exit to library.
2. Launch Reborn. Confirm the game fills the viewport correctly at first frame (no black bars on right, no shrunken letterbox).
3. Exit and re-launch Reborn several times - viewport should remain correct across every session.

Closes the TODO "Viewport letterbox on second-session launch of Pokemon Reborn" item.