### PR TITLE
polish(library): sort grouping, contextual select, artwork shadows, indicator blend-mode

### DIFF
--- a/ios/Empo/src/App/AppSettings.swift
+++ b/ios/Empo/src/App/AppSettings.swift
@@ -18,38 +18,57 @@ enum LibraryDisplayMode: String, CaseIterable {
 enum LibrarySortOption: String, CaseIterable {
     case titleAZ = "titleAZ"
     case titleZA = "titleZA"
+    case recentlyAdded = "recentlyAdded"
+    case leastRecentlyAdded = "leastRecentlyAdded"
     case recentlyPlayed = "recentlyPlayed"
     case leastRecentlyPlayed = "leastRecentlyPlayed"
-    case largestSize = "largestSize"
-    case smallestSize = "smallestSize"
     case mostPlayed = "mostPlayed"
     case leastPlayed = "leastPlayed"
+    case largestSize = "largestSize"
+    case smallestSize = "smallestSize"
 
     var label: String {
         switch self {
         case .titleAZ: "A → Z"
         case .titleZA: "Z → A"
+        case .recentlyAdded: "Recently added"
+        case .leastRecentlyAdded: "Least recently added"
         case .recentlyPlayed: "Recently played"
         case .leastRecentlyPlayed: "Least recently played"
-        case .largestSize: "Largest first"
-        case .smallestSize: "Smallest first"
         case .mostPlayed: "Most played"
         case .leastPlayed: "Least played"
+        case .largestSize: "Largest first"
+        case .smallestSize: "Smallest first"
         }
     }
 
     var icon: String {
         switch self {
-        case .titleAZ: "textformat.abc"
-        case .titleZA: "textformat.abc"
-        case .recentlyPlayed: "clock"
-        case .leastRecentlyPlayed: "clock"
-        case .largestSize: "externaldrive"
-        case .smallestSize: "externaldrive"
-        case .mostPlayed: "hourglass"
-        case .leastPlayed: "hourglass"
+        case .titleAZ, .titleZA: "textformat.abc"
+        case .recentlyAdded, .leastRecentlyAdded: "tray.and.arrow.down"
+        case .recentlyPlayed, .leastRecentlyPlayed: "clock"
+        case .mostPlayed, .leastPlayed: "hourglass"
+        case .largestSize, .smallestSize: "externaldrive"
         }
     }
+
+    /// Groups for the sort sheet. Order here drives section order in
+    /// the UI; each group's options also render in the listed order.
+    static let groups: [LibrarySortGroup] = [
+        LibrarySortGroup(title: "Title", options: [.titleAZ, .titleZA]),
+        LibrarySortGroup(title: "Date", options: [
+            .recentlyAdded, .leastRecentlyAdded,
+            .recentlyPlayed, .leastRecentlyPlayed,
+        ]),
+        LibrarySortGroup(title: "Playtime", options: [.mostPlayed, .leastPlayed]),
+        LibrarySortGroup(title: "Size", options: [.largestSize, .smallestSize]),
+    ]
+}
+
+struct LibrarySortGroup: Identifiable {
+    let title: String
+    let options: [LibrarySortOption]
+    var id: String { title }
 }
 
 enum TitlePosition: String, CaseIterable {

--- a/ios/Empo/src/Design/Theme.swift
+++ b/ios/Empo/src/Design/Theme.swift
@@ -93,8 +93,17 @@ enum Radius {
 
 
 extension View {
+    /// Two-layer shadow used on library artwork tiles and hero
+    /// cards. The tight first layer defines the edge against the
+    /// surface; the diffuse second layer gives ambient elevation.
+    /// MUST be applied after `matchedTransitionSource` in the
+    /// modifier chain - the transition source clips its subtree
+    /// to the configured snapshot bounds, which would crop a
+    /// shadow drawn earlier in the chain.
     func cardShadow() -> some View {
-        shadow(color: .black.opacity(0.15), radius: 4, y: 2)
+        self
+            .shadow(color: .black.opacity(0.05), radius: 1, y: 1)
+            .shadow(color: .black.opacity(0.12), radius: 6, y: 2)
     }
 
     func iconShadow() -> some View {

--- a/ios/Empo/src/Library/GameCard.swift
+++ b/ios/Empo/src/Library/GameCard.swift
@@ -247,13 +247,6 @@ struct GameStatusIndicator: View {
     }
 
     var body: some View {
-        // Glass chrome on every state EXCEPT importing. During
-        // import the ring stands on its own, but its stroke uses
-        // `.regularMaterial` so it adapts to the artwork behind
-        // it - bright on dark scenes, dark on bright scenes -
-        // without needing a glass disc behind it. `.primary` was
-        // failing here: a 0.2-opacity black donut on a sunlit
-        // Pokemon title screen is nearly invisible.
         indicatorBody
             .frame(width: size, height: size)
             .animation(Motion.gentle, value: kind)
@@ -263,12 +256,16 @@ struct GameStatusIndicator: View {
     private var indicatorBody: some View {
         let isImporting = { if case .importing = kind { true } else { false } }()
         let core = ZStack {
+            // Ring + stop render white and blend with `.difference`
+            // so the indicator auto-inverts against whatever's behind
+            // it (library surface in list mode, artwork in grid mode).
+            // CSS `mix-blend-mode: difference` equivalent.
             SpinnerRing(
                 progress: progress,
                 size: ringSize,
                 lineWidth: lineWidth,
-                tint: AnyShapeStyle(.regularMaterial),
-                trackOpacity: 0.35
+                tint: AnyShapeStyle(Color.white),
+                trackOpacity: 0.2
             )
             .opacity(isImporting ? 1 : 0)
             .scaleEffect(isImporting ? 1 : 0.5)
@@ -279,7 +276,7 @@ struct GameStatusIndicator: View {
 
         switch kind {
         case .importing:
-            core
+            core.blendMode(.difference)
         case .paused:
             // Inverted scheme tint so the paused badge reads stronger
             // than the ambient ready state.
@@ -294,11 +291,10 @@ struct GameStatusIndicator: View {
         switch kind {
         case .importing:
             Button(action: { onStopImport?() }) {
-                // Same `.regularMaterial` adaptive contrast as the
-                // ring around it, so stop-square and ring both
-                // stay readable on top of whatever artwork is behind.
+                // White fill paired with the ring's `.blendMode(.difference)`
+                // wrap above. Inverts against whatever's behind.
                 RoundedRectangle(cornerRadius: 2.5)
-                    .fill(.regularMaterial)
+                    .fill(Color.white)
                     .frame(width: stopSize, height: stopSize)
             }
             .buttonStyle(.plain)

--- a/ios/Empo/src/Library/GameCard.swift
+++ b/ios/Empo/src/Library/GameCard.swift
@@ -72,7 +72,9 @@ struct GameCard: View {
             }
             .overlay { centerOverlay }
             .clipShape(.rect(cornerRadius: Radius.md))
-            .cardShadow()
+        // NOTE: cardShadow lives at the GameLibraryView callsite,
+        // not here. Applied AFTER matchedTransitionSource so the
+        // transition source's clip doesn't crop the shadow.
     }
 
 
@@ -83,7 +85,6 @@ struct GameCard: View {
                 .overlay { artworkView }
                 .overlay { centerOverlay }
                 .clipShape(.rect(cornerRadius: Radius.md))
-                .cardShadow()
 
             VStack(spacing: Spacing.xxs) {
                 Text(game.title)
@@ -154,12 +155,12 @@ struct GameListRow: View {
                 cornerRadius: Radius.sm,
                 importing: game.status.phase == .importing
             )
-            .cardShadow()
             .matchedTransitionSource(id: "\(game.id)-item", in: heroNamespace ?? fallbackNamespace) { config in
                 config
                     .background(.black)
                     .clipShape(.rect(cornerRadius: Radius.sm))
             }
+            .cardShadow()
 
             VStack(alignment: .leading, spacing: Spacing.xxs) {
                 Text(game.title)

--- a/ios/Empo/src/Library/GameContextMenu.swift
+++ b/ios/Empo/src/Library/GameContextMenu.swift
@@ -5,6 +5,10 @@ struct GameContextMenuModifier: ViewModifier {
     let game: GameEntry
     var appState: AppState
     let onPlay: () -> Void
+    /// Optional "Select" action that pre-seeds selection mode with
+    /// this game. nil hides the row (e.g. while the library is
+    /// already in selection mode, where the entry would be a no-op).
+    let onSelect: (() -> Void)?
     @Binding var gameToDelete: GameEntry?
     @Binding var showDeleteConfirm: Bool
     @Binding var gameForSettings: GameEntry?
@@ -48,6 +52,13 @@ struct GameContextMenuModifier: ViewModifier {
                 }
             }
 
+            if let onSelect {
+                Divider()
+                Button(action: onSelect) {
+                    Label("Select", systemImage: "checklist")
+                }
+            }
+
             Divider()
 
             Button(role: .destructive) {
@@ -65,6 +76,7 @@ extension View {
     func gameContextMenu(game: GameEntry,
                          appState: AppState,
                          onPlay: @escaping () -> Void,
+                         onSelect: (() -> Void)? = nil,
                          gameToDelete: Binding<GameEntry?>,
                          showDeleteConfirm: Binding<Bool>,
                          gameForSettings: Binding<GameEntry?>,
@@ -73,6 +85,7 @@ extension View {
             game: game,
             appState: appState,
             onPlay: onPlay,
+            onSelect: onSelect,
             gameToDelete: gameToDelete,
             showDeleteConfirm: showDeleteConfirm,
             gameForSettings: gameForSettings,

--- a/ios/Empo/src/Library/GameEntry.swift
+++ b/ios/Empo/src/Library/GameEntry.swift
@@ -39,6 +39,7 @@ struct GameEntry: Identifiable, Hashable {
     // title and showing it twice would be redundant.
     var engineTitle: String? = nil
     var lastPlayed: Date? = nil      // from metadata, cached at scan time
+    var dateAdded: Date? = nil       // from metadata, cached at scan time
     var status: GameStatus = .ready
 
     /// Where the game's own files live. `<container>/Game/`. Empty
@@ -65,6 +66,7 @@ struct GameEntry: Identifiable, Hashable {
         lhs.id == rhs.id && lhs.status == rhs.status && lhs.title == rhs.title
             && lhs.container == rhs.container && lhs.artworkPath == rhs.artworkPath
             && lhs.engineTitle == rhs.engineTitle && lhs.lastPlayed == rhs.lastPlayed
+            && lhs.dateAdded == rhs.dateAdded
     }
 
 

--- a/ios/Empo/src/Library/GameHeroCard.swift
+++ b/ios/Empo/src/Library/GameHeroCard.swift
@@ -121,13 +121,13 @@ struct GameHeroCard: View {
                         .accessibilityHidden(true)
                 }
                 .clipShape(.rect(cornerRadius: Radius.lg))
-                .cardShadow()
                 .matchedTransitionSource(id: GameTapSource.hero.transitionID(for: game.id),
                                          in: heroNamespace) { config in
                     config
                         .background(.black)
                         .clipShape(.rect(cornerRadius: Radius.lg))
                 }
+                .cardShadow()
         }
         .buttonStyle(CardPressStyle())
         .gameContextMenu(game: game, appState: appState, onPlay: onTap, gameToDelete: $gameToDelete, showDeleteConfirm: $showDeleteConfirm, gameForSettings: $gameForSettings, gameForInfo: $gameForInfo)

--- a/ios/Empo/src/Library/GameLibrary.swift
+++ b/ios/Empo/src/Library/GameLibrary.swift
@@ -217,7 +217,8 @@ class GameLibrary {
             title: title,
             artworkPath: artworkPath,
             engineTitle: engineTitle,
-            lastPlayed: metadata.lastPlayed
+            lastPlayed: metadata.lastPlayed,
+            dateAdded: metadata.dateAdded
         )
     }
 
@@ -420,6 +421,7 @@ class GameLibrary {
                     artworkPath: artworkPath,
                     engineTitle: lib.games[idx].engineTitle,
                     lastPlayed: lib.games[idx].lastPlayed,
+                    dateAdded: lib.games[idx].dateAdded,
                     status: lib.games[idx].status
                 )
             }

--- a/ios/Empo/src/Library/GameLibraryView.swift
+++ b/ios/Empo/src/Library/GameLibraryView.swift
@@ -387,9 +387,7 @@ struct GameLibraryView: View {
                 Task { @MainActor in
                     staggerTrigger = UUID()
                 }
-            },
-            onSelectMultiple: { enterSelectionMode() },
-            hideSelectMultiple: selectionMode
+            }
         )
     }
 
@@ -530,6 +528,7 @@ struct GameLibraryView: View {
                     game: game,
                     appState: appState,
                     onPlay: { handleGameTap(game, from: .item) },
+                    onSelect: selectionMode ? nil : { enterSelectionMode(seedingWith: game.id) },
                     gameToDelete: $gameToDelete,
                     showDeleteConfirm: $showDeleteConfirm,
                     gameForSettings: $gameForSettings,
@@ -557,6 +556,7 @@ struct GameLibraryView: View {
                 game: pending,
                 onStopImport: { showCancelValidationAlert = true }
             )
+            .cardShadow()
             .id("\(pending.id)-pending")
             .transition(.cardAppear)
         }
@@ -568,6 +568,7 @@ struct GameLibraryView: View {
                     gameToDelete = game
                     showDeleteConfirm = true
                 })
+                    .cardShadow()
                     .id("\(game.id)-importing")
                     .transition(.cardAppear)
                     .staggered(index: index, trigger: staggerTrigger, initialDelay: entranceDelay)
@@ -575,6 +576,7 @@ struct GameLibraryView: View {
             case .invalid:
                 Button { handleCardTap(for: game) } label: {
                     GameCard(game: game)
+                        .cardShadow()
                 }
                     .id("\(game.id)-invalid")
                     .buttonStyle(CardPressStyle())
@@ -600,6 +602,7 @@ struct GameLibraryView: View {
                                 .background(.black)
                                 .clipShape(.rect(cornerRadius: Radius.md))
                         }
+                        .cardShadow()
                         .overlay(alignment: .topTrailing) {
                             if selectionMode {
                                 selectionBadge(for: game.id)
@@ -621,6 +624,7 @@ struct GameLibraryView: View {
                     game: game,
                     appState: appState,
                     onPlay: { handleGameTap(game, from: .item) },
+                    onSelect: selectionMode ? nil : { enterSelectionMode(seedingWith: game.id) },
                     gameToDelete: $gameToDelete,
                     showDeleteConfirm: $showDeleteConfirm,
                     gameForSettings: $gameForSettings,

--- a/ios/Empo/src/Library/GameSorting.swift
+++ b/ios/Empo/src/Library/GameSorting.swift
@@ -9,6 +9,10 @@ extension LibrarySortOption {
             return games.sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
         case .titleZA:
             return games.sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedDescending }
+        case .recentlyAdded:
+            return games.sorted { ($0.dateAdded ?? .distantPast) > ($1.dateAdded ?? .distantPast) }
+        case .leastRecentlyAdded:
+            return games.sorted { ($0.dateAdded ?? .distantPast) < ($1.dateAdded ?? .distantPast) }
         case .recentlyPlayed:
             return games.sorted { ($0.lastPlayed ?? .distantPast) > ($1.lastPlayed ?? .distantPast) }
         case .leastRecentlyPlayed:

--- a/ios/Empo/src/Library/LibrarySearchBar.swift
+++ b/ios/Empo/src/Library/LibrarySearchBar.swift
@@ -2,17 +2,12 @@ import SwiftUI
 
 /// Search bar + sort + grid/list toggle shown at the top of the library.
 /// Own state stays on GameLibraryView; this view just renders bindings.
+/// Multi-select entry now lives in each game's context menu instead.
 
 struct LibrarySearchBar: View {
     @Binding var searchText: String
     @Binding var showSortSheet: Bool
     let onDisplayModeToggle: () -> Void
-    let onSelectMultiple: () -> Void
-    /// Hide the Select-multiple icon while the library is already
-    /// in selection mode (the header's "Done" button is the exit
-    /// affordance). Search / sort / display-mode stay available so
-    /// users can find specific games to add to the selection.
-    var hideSelectMultiple: Bool = false
     @Environment(\.appSettings) private var settings
 
     private let searchBarHeight: CGFloat = 44
@@ -53,19 +48,6 @@ struct LibrarySearchBar: View {
                 onDisplayModeToggle()
             }
             .accessibilityLabel(settings.libraryDisplayMode == .grid ? "Switch to list" : "Switch to grid")
-
-            // Multi-select entry point. Sits in the same row as
-            // sort and grid/list because all three are "act on the
-            // library" actions. Top-right of the header is owned by
-            // the floating ImportButton, so this stays here even
-            // though it's the kind of action a user might also
-            // expect in the header chrome.
-            if !hideSelectMultiple {
-                IconButton("checkmark.circle", style: .outline) {
-                    onSelectMultiple()
-                }
-                .accessibilityLabel("Select multiple games")
-            }
         }
         .padding(.horizontal)
         .padding(.bottom, Spacing.xs)

--- a/ios/Empo/src/Library/LibrarySortSheet.swift
+++ b/ios/Empo/src/Library/LibrarySortSheet.swift
@@ -10,29 +10,15 @@ struct LibrarySortSheet: View {
     var body: some View {
         NavigationStack {
             List {
-                ForEach(LibrarySortOption.allCases, id: \.self) { option in
-                    Button {
-                        withAnimation(Motion.standard) {
-                            settings.librarySortOption = option
-                        }
-                        isPresented = false
-                    } label: {
-                        HStack(spacing: Spacing.lg) {
-                            Image(systemName: option.icon)
-                                .foregroundStyle(.secondary)
-                                .frame(width: 24)
-                            Text(option.label)
-                            Spacer()
-                            if settings.librarySortOption == option {
-                                Image(systemName: "checkmark")
-                                    .foregroundStyle(.brand)
-                                    .fontWeight(.semibold)
-                            }
+                ForEach(LibrarySortOption.groups) { group in
+                    Section(group.title) {
+                        ForEach(group.options, id: \.self) { option in
+                            row(for: option)
                         }
                     }
-                    .tint(.primary)
                 }
             }
+            .listStyle(.insetGrouped)
             .navigationTitle("Sort by")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -41,8 +27,31 @@ struct LibrarySortSheet: View {
                 }
             }
         }
-        .presentationDetents([.medium])
+        .presentationDetents([.medium, .large])
         .presentationDragIndicator(.visible)
         .tint(.brand)
+    }
+
+    private func row(for option: LibrarySortOption) -> some View {
+        Button {
+            withAnimation(Motion.standard) {
+                settings.librarySortOption = option
+            }
+            isPresented = false
+        } label: {
+            HStack(spacing: Spacing.lg) {
+                Image(systemName: option.icon)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 24)
+                Text(option.label)
+                Spacer()
+                if settings.librarySortOption == option {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(.brand)
+                        .fontWeight(.semibold)
+                }
+            }
+        }
+        .tint(.primary)
     }
 }


### PR DESCRIPTION
## Summary

Library UX polish pass on top of the cleanup PR (#38). All small, additive UI fixes.

### Sort sheet
- Two new options: **Recently added** and **Least recently added**, backed by a `dateAdded` field on \`GameEntry\` cached at scan time from \`GameMetadata\`.
- Grouped sort sheet into four sections: **Title**, **Date** (added + played), **Playtime**, **Size**. Driven by a static \`LibrarySortGroup\` table on \`LibrarySortOption\` so adding a new option means slotting it into the right group.
- Detents bumped to \`[.medium, .large]\` since the grouped list pushes past medium height.

### Select multiple
- Removed the \`checkmark.circle\` icon button from \`LibrarySearchBar\` (header is leaner now).
- Added **Select** entry to \`GameContextMenu\` between Settings and Delete. Long-press → Select pre-seeds selection mode with that game (uses the existing \`enterSelectionMode(seedingWith:)\` path).
- Hidden when already in selection mode and on \`.invalid\` cards (selection badge can't render on them anyway).

### Artwork drop shadows
- \`cardShadow()\` was being clipped invisible on every callsite because \`matchedTransitionSource\` clips its source view's subtree to the configured snapshot bounds, cropping any shadow drawn earlier in the modifier chain.
- Reordered: shadow now applies AFTER \`matchedTransitionSource\` in \`GameHeroCard\`, \`GameListRow\`, and the grid \`.ready\` callsite in \`GameLibraryView\`.
- Lifted \`cardShadow\` out of \`GameCard.insideCard\` / \`underCard\` internals so the grid callsite controls modifier order. Added at all 4 grid callsites.
- Switched to a softer two-layer shadow (0.05 + 0.12 alpha, 1pt and 6pt blur) since one-layer with the previous 0.15 single-layer was invisible on the warm cream \`surface\`.

### Import progress indicator
- Replaced \`.regularMaterial\`-tinted spinner + stop with white fill wrapped in \`.blendMode(.difference)\`. Material adaptive contrast washed out on flat backgrounds (cream library surface); difference-blend auto-inverts against any backdrop - white on dark artwork, dark on light surface.
- Track opacity dropped from 0.35 to 0.2 since white reads stronger than material at the same alpha.

## Stacked
- Base: \`cleanup/codebase-audit\` (PR #38)
- When #38 merges, this PR's base auto-retargets to \`main\`.