### PR TITLE
docs: full audit pass + ux: delay stuck-loading message

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Status](https://img.shields.io/badge/status-pre--release-yellow.svg)](#status)
 [![Platform](https://img.shields.io/badge/platform-iOS%2026%2B-lightgrey.svg)](#requirements)
 
-Empo wraps the [mkxp-z](https://github.com/mkxp-z/mkxp-z) RPG Maker engine in a native SwiftUI library and a customizable touch-controls overlay. Vintage RPG Maker XP / VX / VX Ace games and modern Pokemon Essentials forks all run on-device, no desktop emulator needed.
+Empo wraps the [mkxp-z](https://github.com/mkxp-z/mkxp-z) RPG Maker engine in a native SwiftUI library and a customizable touch-controls overlay. RPG Maker XP / VX / VX Ace games and modern Pokemon Essentials forks run on-device, no desktop emulator needed.
 
 ## Table of Contents
 
@@ -23,8 +23,8 @@ Empo wraps the [mkxp-z](https://github.com/mkxp-z/mkxp-z) RPG Maker engine in a 
 
 ## Highlights
 
-- Plays games made for RGSS1 (XP), RGSS2 (VX), RGSS3 (VX Ace), and the modern mkxp-z fork ecosystem (Reborn, Vanguard, Flux, Insurgence, Infinite Fusion, etc.).
-- **Multi-Ruby native dispatch.** Four Ruby interpreters (1.8, 1.9, 3.0, 3.1) share one binary; each game runs on the actual Ruby version it was authored against. See [`docs/multi-ruby.md`](docs/multi-ruby.md).
+- Plays games made for RGSS1 (XP), RGSS2 (VX), RGSS3 (VX Ace), and modern mkxp-z forks.
+- **Multi-Ruby native dispatch.** Four Ruby interpreters (1.8, 1.9, 3.0, 3.1) ship in one binary; each game runs on the actual Ruby version it was authored against. See [`docs/multi-ruby.md`](docs/multi-ruby.md).
 - Imports games from folders, `.zip`, `.7z`, `.rar`, and JoiPlay's `.jgp` format.
 - Customizable on-screen D-pad and action buttons, with per-game layouts.
 - Pause and resume from the library; a frozen-frame snapshot bridges SDL into the SwiftUI hero zoom transition.
@@ -41,7 +41,6 @@ End-to-end working across the RGSS1/2/3 and modern mkxp-z fork landscape. Compat
 - **Single game per session.** After exiting a game, force-close + reopen Empo from the app switcher to start a different one. Cross-session play is parked pending reliable Ruby state cleanup; see [`docs/multi-session.md`](docs/multi-session.md).
 - **Ogg/Theora movies only.** MP4 and other formats are skipped silently.
 - **Native Windows DLL dependencies.** Games leaning on Win32 APIs beyond what the engine's `win32_wrap.rb` emulates may fail to load some assets.
-- **Simulator rotation.** Rotating the iOS Simulator during gameplay crashes inside Apple's GL emulation layer. Real devices are fine.
 
 ## How it works
 
@@ -67,9 +66,9 @@ For deeper architectural context:
 
 A few load-bearing tricks worth flagging if you're poking around:
 
+- **Multi-Ruby in one binary.** Four Ruby versions (1.8, 1.9, 3.0, 3.1) compile separately, then each version's libruby + binding code merges into a single relocatable `.o` with hidden symbol islanding via `ld -r --unexported_symbols_list`. Each `.o` exports exactly one global, `_mkxp_get_script_binding_NN`. The host calls `mkxp_setActiveRubyVersion()` per game and the engine dispatches accordingly. See [`docs/multi-ruby.md`](docs/multi-ruby.md).
 - **Persistent SDL + Ruby VM.** SDL, the GL context, OpenAL, and the active Ruby interpreter are created once and reused for the process lifetime. iOS doesn't let apps relaunch themselves between games, and CRuby's `ruby_init()` is one-shot per process.
-- **Per-version merged `.o` for Ruby.** Each Ruby version's libruby + binding compile separately, then `ld -r --unexported_symbols_list` hides every Ruby internal so all four versions can coexist in one binary. Each `.o` exports exactly one global: `_mkxp_get_script_binding_NN`.
-- **Syntax transform on Ruby 3.1 only.** Mixed-grammar Pokemon Essentials forks (Vinemon, Sauce Edition, etc.) combine 1.8 syntax with 1.9+ runtime methods. They can't run on 1.8 native (no `force_encoding`) or vanilla 3.1 (parser rejects `when X:`). The 3.1 binding ships [PR #304's syntax-transform patches](https://github.com/mkxp-z/mkxp-z/pull/304); the host activates LEGACY mode per game.
+- **Syntax-transform patches on Ruby 3.1.** The Ruby 3.1 build also applies [PR #304's parser patches](https://github.com/mkxp-z/mkxp-z/pull/304) so mixed-grammar Pokemon Essentials forks (1.8 syntax + 1.9+ runtime methods) parse on Ruby 3.1's VM. The host activates LEGACY mode per game where needed; otherwise vanilla 3.1 parsing applies.
 - **Win32 emulation in Ruby.** [`win32_wrap.rb`](mkxp-z-apple-mobile/scripts/preload/win32_wrap.rb) (CC0, by Ancurio and Splendide Imaginarius) plus [`platform_compat.rb`](mkxp-z-apple-mobile/scripts/preload/platform_compat.rb) stub out the Windows APIs games expect, neutralize `system`/`fork`/`spawn` so games can't launch new processes, and swallow load errors from encrypted archives.
 - **Touch controls via SDL events.** The overlay calls `SDL_PushEvent` with synthetic key events, so the engine sees them exactly as if they came from a hardware keyboard. New buttons or layouts need no engine changes.
 
@@ -149,6 +148,6 @@ Issues, ideas, and PRs welcome.
 - [Ancurio](https://github.com/Ancurio) for the original [mkxp](https://github.com/Ancurio/mkxp) engine.
 - The [mkxp-z contributors](https://github.com/mkxp-z/mkxp-z/graphs/contributors) for keeping it alive on desktop.
 - [JoiPlay](https://github.com/joiplay) for the [Ruby 1.8 cross-compilation work](https://github.com/joiplay/ruby) and the multi-Ruby dispatch model their RPG Maker plugin uses.
-- [white-axe](https://github.com/white-axe) for [PR #304](https://github.com/mkxp-z/mkxp-z/pull/304), the Ruby 3.1 syntax-transform patches that keep mixed-grammar Pokemon Essentials forks running.
-- [MGC](https://www.save-point.org/thread-3151.html) for the original H-Mode7 RPG Maker XP plugin (the pseudo-3D renderer behind Pokemon Insurgence's flying intro). Our [native port](mkxp-z-apple-mobile/hmode7) re-implements it on mkxp-z's `Bitmap` and `Table` APIs.
+- [white-axe](https://github.com/white-axe) for [PR #304](https://github.com/mkxp-z/mkxp-z/pull/304), the Ruby 3.1 syntax-transform patches that mkxp-z-apple-mobile applies to its 3.1 build.
+- [MGC](https://www.save-point.org/thread-3151.html) for the original H-Mode7 RPG Maker XP plugin. The [native port](mkxp-z-apple-mobile/hmode7) re-implements it on mkxp-z's `Bitmap` and `Table` APIs.
 - [Splendide Imaginarius](https://github.com/Splendide-Imaginarius) for the `win32_wrap.rb` extensions that keep Windows-only RPG Maker games loading on non-Windows targets.

--- a/docs/multi-ruby.md
+++ b/docs/multi-ruby.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Empo ships four Ruby interpreters in one binary - 1.8.8, 1.9.3, 3.0.7, 3.1.3 - and dispatches to the right one per-game at launch. A vintage RPG Maker XP game runs on actual Ruby 1.8's parser and VM. A Pokemon Reborn 19+ build runs on Ruby 3.1. Ruby 3.0 ships too and is available as a manual override via the per-game Ruby Version picker for runtimes built against 3.0 specifically.
+Empo ships four Ruby interpreters in one binary - 1.8.8, 1.9.3, 3.0.7, 3.1.3 - and dispatches to the right one per-game at launch. A vintage RPG Maker XP game runs on actual Ruby 1.8's parser and VM. A modern Pokemon Essentials fork built on the mkxp-z runtime routes to Ruby 3.1. Ruby 3.0 ships too and is available as a manual override via the per-game Ruby Version picker for runtimes built against 3.0 specifically.
 
 This replaces the older "everything on one Ruby" architecture (originally 1.8-only, briefly 3.1-only via the syntax-transform PR304 experiment).
 
@@ -12,10 +12,10 @@ Different RPG Maker generations target different Ruby versions:
 
 | Generation | Engine DLL | Ruby version | Typical games |
 |---|---|---|---|
-| RGSS1 (RPG Maker XP) | `RGSS104E.dll` | 1.8 | Vintage Pokemon Essentials forks (Pokemon Z, Insurgence, Uranium) |
+| RGSS1 (RPG Maker XP) | `RGSS104E.dll` | 1.8 | Vintage Pokemon Essentials forks |
 | RGSS2 (RPG Maker VX) | `RGSS200J.dll` | 1.9 | A handful of community projects |
-| RGSS3 (RPG Maker VX Ace) | `RGSS300.dll` | 1.9 | BTTheManor, traditional VX Ace games |
-| mkxp-z modern | bundled `x64-msvcrt-rubyXYZ.dll` | 3.0 / 3.1 | Modern PE forks (Reborn 19+, Vanguard, Flux, Inf Fusion) |
+| RGSS3 (RPG Maker VX Ace) | `RGSS300.dll` | 1.9 | Traditional VX Ace games |
+| mkxp-z modern | bundled `x64-msvcrt-rubyXYZ.dll` | 3.0 / 3.1 | Modern Pokemon Essentials forks shipping the mkxp-z runtime |
 
 A single Ruby version that tries to cover all of these is fragile. Ruby 1.8 can't parse modern code (keyword args, safe nav, pattern matching). Ruby 3.x can't parse a lot of vintage code (`when X:`, character literal arithmetic, removed `Object#id`). Source-rewrite hacks like the syntax-transform patches make 3.1 accept some 1.8 grammar but break in subtle ways for genuinely modern games (see "Syntax transform stays" below).
 
@@ -108,26 +108,55 @@ The same `binding/*.cpp` source compiles four times, with version-conditional co
 
 Includes are isolated under `$(INCLUDEDIR)/ruby${VER}/` so 3.0 doesn't accidentally see 3.1 headers and vice versa.
 
-## Syntax transform stays
+## Syntax transform
 
-The Ruby 3.1 build still applies the syntax-transform patches (see `mkxp-z-apple-mobile/syntax-transform/3.1/`). These rewrite Ruby 3.1's parser to also accept Ruby 1.8 grammar. Activated per-game via `mkxp_setSyntaxTransformMode()`:
+The Ruby 3.1 build applies a set of parser patches (33 files under `mkxp-z-apple-mobile/syntax-transform/3.1/`, originally [PR #304 by white-axe](https://github.com/mkxp-z/mkxp-z/pull/304)) that teach Ruby 3.1's parser to also accept Ruby 1.8 grammar. The 1.8 / 1.9 / 3.0 builds don't apply them; those interpreters parse their native grammar without modification.
 
-- **DISABLED** (modern PE forks: Reborn, Flux, Vanguard, Inf Fusion) - strict Ruby 3.1 parsing.
-- **LEGACY** (mixed-grammar PE forks: Vinemon, etc.) - 1.8 syntax accepted by parser.
+### Why it exists
 
-The 1.8 / 1.9 / 3.0 builds run vanilla Ruby - the patches don't apply there.
+Multi-Ruby native dispatch covers most of the compatibility space, but it doesn't cover one shape of game: mixed-grammar Pokemon Essentials forks that combine Ruby 1.8-era syntax with 1.9+ runtime methods.
 
-This is the safety net for one specific case: games that have 1.8-era syntax (`when X:`, `break` from proc, `?A` as integer) but use 1.9+ runtime methods (`force_encoding`, `String#encode`, modern Time API). They can't run on 1.8 native (no `force_encoding`) or 3.1 native strict (parser rejects `when X:`). Patched 3.1 with LEGACY mode is the only path.
+Concretely:
 
-`GameSettings.useModernRuby` (auto-detected via `detectModernRubyScripts`) picks DISABLED vs LEGACY at session start. Manual override via the per-game settings sheet.
+- **Ruby 1.8 syntax**: `when X:` (colon-terminated when clause), `break` from inside a `Proc.new` block, `?A` evaluated to an integer character code, `Object#id`, `Array#choice`, `Symbol#to_i`.
+- **Ruby 1.9+ runtime methods**: `String#force_encoding`, `String#encode`, modern `Time` API, `Encoding` constants.
 
-We tried stripping syntax-transform under the assumption that multi-Ruby native made it dead code. That assumption was wrong - Vinemon and similar mixed-grammar forks legitimately need the patched parser. The strip experiment was reverted.
+A single interpreter that accepts both doesn't exist:
+
+- Ruby 1.8 native parses the syntax fine but lacks the runtime methods (no `force_encoding`).
+- Ruby 3.1 native has all the runtime methods but its parser rejects `when X:` outright.
+
+Patched Ruby 3.1 with the syntax-transform parser patches is the only path that runs these games. The patches activate selectively at parse time, gated by a global; the runtime methods stay vanilla Ruby 3.1.
+
+### Why only on Ruby 3.1
+
+The 1.8 / 1.9 / 3.0 builds don't need the patches. Each of those interpreters runs games written in its own native grammar (via the multi-Ruby dispatcher), so there's no parser-mismatch problem to solve.
+
+The patches themselves target Ruby 3.1's parser internals (`parse.y`, `compile.c`, `vm_method.c`, etc.). Porting them to 3.0 or 1.9 would require re-deriving 33 patches against a different parser tree for no gain: a game that wants 1.9 grammar already gets 1.9 native, and a game that wants 3.0 already gets 3.0 native.
+
+### When it activates
+
+Per-session, set by the host before `mkxp_setGamePath()`:
+
+| Mode | When | Effect |
+|---|---|---|
+| `MKXP_SYNTAX_TRANSFORM_DISABLED` | Game routes to Ruby 3.1 and `useModernRuby = true` (auto-detected, or manually picked) | Vanilla Ruby 3.1 parsing. Modern grammar required. |
+| `MKXP_SYNTAX_TRANSFORM_LEGACY` | Game routes to Ruby 3.1 and `useModernRuby = false` (default for mixed-grammar PE forks) | Patches active. Parser accepts 1.8 grammar. |
+| `MKXP_SYNTAX_TRANSFORM_UNSET` | Default at startup; engine falls back to mkxp.json's value (legacy desktop path). | The iOS host always sets a real value, so UNSET stays as a guard for desktop / test-harness builds. |
+
+`GameSettings.useModernRuby` is the per-game switch. `GameSettings.detectModernRubyScripts` auto-sets it at import time based on heuristics (bundled DLL filename, presence of modern grammar tokens in loose `.rb` files, `.fpk` packaging). The user can override via the per-game settings sheet.
+
+The patches are no-ops at the engine level when `MKXPZ_HAVE_SYNTAX_TRANSFORM_PATCHES` isn't defined (they're gated on the build define). The 1.8 / 1.9 / 3.0 builds don't define it; only the Ruby 3.1 build does.
+
+### History
+
+A previous iteration tried stripping the syntax-transform patches under the assumption that multi-Ruby native dispatch made them dead code. The assumption was wrong: mixed-grammar Pokemon Essentials forks legitimately need the patched parser. The strip experiment was reverted.
 
 ## Quit handling
 
 Ruby's `Kernel.exit!` and `Process.exit!` skip `at_exit` handlers AND bypass the engine's SystemExit catch entirely - they call C `_exit(status)` directly, terminating the iOS process before mkxp-z can save the engine log, fire the `mkxp_setEngineTerminated` callback, or do anything else.
 
-Pokemon Essentials' `pbExit` (and many forks - Vanguard, Reborn) commonly use `exit!` to skip a "press any key to confirm" splash. On desktop that's a fine UX choice; on iOS it makes the app vanish silently, status 1, no signal, no crash report.
+Pokemon Essentials' `pbExit` and various forks of it commonly use `exit!` to skip a "press any key to confirm" splash. On desktop that's a fine UX choice; on iOS it makes the app vanish silently, status 1, no signal, no crash report. Apple's App Store review guideline 2.5.1 also explicitly forbids programmatic process termination, so the `exit!` path needs to be intercepted regardless.
 
 `scripts/preload/platform_compat.rb` redirects `Kernel.exit!` and `Process.exit!` to `Kernel.exit` so the engine's SystemExit catch in `binding-mri.cpp`'s eval loop runs, sets `mkxp_setEngineExitedCleanly()`, and the iOS host's clean-exit alert ("close from app switcher") appears as designed.
 

--- a/docs/multi-session.md
+++ b/docs/multi-session.md
@@ -14,7 +14,7 @@ iOS apps can't kill themselves and respawn. Android emulators (JoiPlay) sidestep
 - Game B runs in the same VM. It defines `class Foo < Baz`. Ruby raises `TypeError: superclass mismatch for class Foo`.
 - The hierarchy of leaked classes / monkey-patches / aliases / disposed RGSS objects across two arbitrary games' scripts is unpredictable.
 
-A previous iteration shipped aggressive cross-session cleanup (constant-baseline diffing, singleton-method baseline, `MkxpNullMouse` shim for orphan globals, intrusive-list detachment for disposables, etc.) and it worked for Pokemon Z ↔ Pokemon Uranium. It didn't survive contact with broader game corpora - especially mixed-version sessions where the active Ruby's data structures differ between games.
+A previous iteration shipped aggressive cross-session cleanup (constant-baseline diffing, singleton-method baseline, `MkxpNullMouse` shim for orphan globals, intrusive-list detachment for disposables, etc.) and it worked for narrow same-version game pairs. It didn't survive contact with broader game corpora, especially mixed-version sessions where the active Ruby's data structures differ between games.
 
 The decision: rather than ship a half-working cross-session UX that breaks unpredictably, we surface a clean alert that asks the user to force-close. Future work could re-enable cross-session play either via process forking (separate PID per game) or by moving the engine's per-session VM state into a fully resettable container.
 
@@ -34,7 +34,7 @@ Even though the user can't switch to another game in the same process, the engin
 
 Two `scripts/preload/platform_compat.rb` shims keep this flow working when game scripts try to skip the engine's catch:
 
-- **`Kernel.exit!` / `Process.exit!` redirect to `Kernel.exit`** - Pokemon Essentials' `pbExit` (and forks like Vanguard) calls `exit!` to skip `at_exit` handlers. On desktop that's harmless; on iOS `exit!` calls C `_exit(status)` directly and the app vanishes before the engine knows. Redirecting to `exit` raises `SystemExit` instead, which the engine catches.
+- **`Kernel.exit!` / `Process.exit!` redirect to `Kernel.exit`** - Pokemon Essentials' `pbExit` and various forks of it call `exit!` to skip `at_exit` handlers. On desktop that's harmless; on iOS `exit!` calls C `_exit(status)` directly and the app vanishes before the engine knows. Redirecting to `exit` raises `SystemExit` instead, which the engine catches. App Store guideline 2.5.1 also forbids programmatic process termination, so the redirect serves both correctness and policy.
 - **`Thread.critical` / `Thread.critical=` no-ops on Ruby 1.9+** - Vintage RGSS code wraps `Marshal.load` and save-file I/O in `Thread.critical = true` blocks (a Ruby 1.8 cooperative-scheduling idiom; both methods removed in 1.9). Without the shim, Ruby 1.9+ raises `NoMethodError` mid-quit, the error escapes the script-eval loop, and `SharedState::finiInstance()` segfaults on iOS while tearing down graphics with a pending exception.
 
 See `docs/multi-ruby.md` for the broader picture.

--- a/ios/Dependencies/pixman/PATCHES.md
+++ b/ios/Dependencies/pixman/PATCHES.md
@@ -1,4 +1,4 @@
-# Pixman — Patches & Build Notes
+# Pixman: Patches & Build Notes
 
 ## Source
 
@@ -24,7 +24,7 @@ Built with Autotools:
 
 Key flags:
 
-- `--disable-arm-a64-neon` — Required to avoid NEON assembly issues when
+- `--disable-arm-a64-neon`: Required to avoid NEON assembly issues when
   cross-compiling for iOS ARM64. Without this flag, the build attempts to
   use A64 NEON intrinsics that cause compilation failures with the iOS
   toolchain.

--- a/ios/Dependencies/ruby18/PATCHES.md
+++ b/ios/Dependencies/ruby18/PATCHES.md
@@ -1,10 +1,10 @@
-# Ruby 1.8 — Patches & Build Notes
+# Ruby 1.8: Patches & Build Notes
 
 ## Source
 
-- **Upstream**: JoiPlay's `ruby_1_8` branch — <https://github.com/joiplay/ruby>
+- **Upstream**: JoiPlay's `ruby_1_8` branch: <https://github.com/joiplay/ruby>
 - **Branch**: `ruby_1_8` (submodule at `sources/ruby18`)
-- **Commit**: `50783b8` ("\* 2014-01-28") — git-svn mirror of the
+- **Commit**: `50783b8` ("\* 2014-01-28"): git-svn mirror of the
   official Ruby SVN repository (revision 44718)
 - **Reported version**: 1.8.8 (per `version.h`)
 - **Note**: Last maintenance snapshot of Ruby 1.8, frozen since 2014.
@@ -13,17 +13,16 @@
 
 Most RPG Maker XP games (RGSS1) were written against Ruby 1.8. Empo's
 multi-Ruby dispatcher routes detected RGSS1 games to this build (see
-`docs/multi-ruby.md`) so vintage Pokemon Essentials forks (Pokemon Z,
-Insurgence, Uranium, etc.) run on the parser they were authored
-against, instead of going through Ruby 3.1's syntax-transform
-patches.
+`docs/multi-ruby.md`) so vintage Pokemon Essentials forks run on the
+parser they were authored against, instead of going through Ruby 3.1's
+syntax-transform patches.
 
 ## Patches
 
 All iOS patches are in `ios.patch` (applied automatically by the makefile
 via `git apply` before `autoconf`):
 
-### `config.guess` and `config.sub` — Updated for aarch64
+### `config.guess` and `config.sub`: Updated for aarch64
 
 The original 2014-era autoconf helper scripts do not recognize modern
 platform triplets like `aarch64-apple-darwin`. Both files were replaced
@@ -37,24 +36,24 @@ These are the ONLY modifications to the JoiPlay Ruby 1.8 source.
 These are not patches to Ruby itself, but critical engine adaptations
 required to make Ruby 1.8 work on iOS:
 
-1. **4MB RGSS thread stack** — Ruby 1.8's GC (`mark_locations_array`)
+1. **4MB RGSS thread stack**: Ruby 1.8's GC (`mark_locations_array`)
    scans the entire thread stack for object references. The default 512KB
    iOS pthread stack causes SIGBUS when GC hits the guard page. Fixed by
    using `SDL_CreateThreadWithStackSize` with 4MB.
 
-2. **GC stack base update** — `rb_gc_stack_start` (global in `gc.c`)
+2. **GC stack base update**: `rb_gc_stack_start` (global in `gc.c`)
    records the stack base at `ruby_init()` time. Since `ruby_init()` is
    only called once (CRuby 1.8 cannot be restarted), subsequent RGSS
    threads have different stacks but GC still scans the old one, causing
    SIGSEGV. Fixed by force-updating `rb_gc_stack_start` at the start of
    each session via `extern VALUE *rb_gc_stack_start`.
 
-3. **VM persistence** — CRuby 1.8's VM cannot be restarted
+3. **VM persistence**: CRuby 1.8's VM cannot be restarted
    (`ruby_cleanup()` + `ruby_init()` causes SIGSEGV). The engine calls
    `ruby_init()` and `Init_*()` only once, and on subsequent game
    sessions clears leftover Ruby state with `rb_eval_string_protect`.
 
-4. **RAPI clamping** — `RAPI_FULL=188` is clamped to `187` so the engine
+4. **RAPI clamping**: `RAPI_FULL=188` is clamped to `187` so the engine
    selects the RGSS1 binding codepath.
 
 ## iOS Build Instructions
@@ -83,11 +82,11 @@ The makefile automatically:
 
 ### Key build flags
 
-- `-std=gnu89` — Required because Ruby 1.8 is K&R-style C code
-- `-Wno-implicit-function-declaration`, `-Wno-implicit-int`, etc. —
-  Suppress warnings-turned-errors for legacy C code
-- `--host=aarch64-apple-darwin --build=x86_64-apple-darwin` —
-  Cross-compilation triple
+- `-std=gnu89`: Required because Ruby 1.8 is K&R-style C code
+- `-Wno-implicit-function-declaration`, `-Wno-implicit-int`, etc.:
+  suppress warnings-turned-errors for legacy C code
+- `--host=aarch64-apple-darwin --build=x86_64-apple-darwin`:
+  cross-compilation triple
 
 ### Output
 

--- a/ios/Dependencies/ruby19/PATCHES.md
+++ b/ios/Dependencies/ruby19/PATCHES.md
@@ -1,4 +1,4 @@
-# Ruby 1.9 — Patches & Build Notes
+# Ruby 1.9: Patches & Build Notes
 
 ## Source
 
@@ -20,7 +20,7 @@ without falling back to Ruby 3.1's syntax-transform patches.
 All iOS patches are in `ios.patch` (applied automatically by the
 makefile via `git apply` before `autoconf`):
 
-### `config.guess` and `config.sub` — Updated for aarch64
+### `config.guess` and `config.sub`: Updated for aarch64
 
 The 2014-era autoconf helper scripts don't recognize modern platform
 triplets like `aarch64-apple-darwin`. Both files were replaced with
@@ -31,12 +31,12 @@ current GNU config versions so cross-compilation to iOS works.
 These are not patches to Ruby itself, but engine-side adaptations
 required for Ruby 1.9 on iOS:
 
-1. **4MB RGSS thread stack** — Ruby 1.9's GC scans the entire thread
+1. **4MB RGSS thread stack**: Ruby 1.9's GC scans the entire thread
    stack for object references. The default 512KB iOS pthread stack
    triggers SIGBUS when GC hits the guard page. Worked around by
    calling `SDL_CreateThreadWithStackSize` with 4MB.
 
-2. **VM persistence** — `ruby_init()` is one-shot per process; the
+2. **VM persistence**: `ruby_init()` is one-shot per process; the
    engine calls it once and reuses the VM across game sessions for
    the lifetime of the app.
 

--- a/ios/Dependencies/ruby30/PATCHES.md
+++ b/ios/Dependencies/ruby30/PATCHES.md
@@ -1,4 +1,4 @@
-# Ruby 3.0 — Patches & Build Notes
+# Ruby 3.0: Patches & Build Notes
 
 ## Source
 
@@ -21,13 +21,13 @@ All iOS patches are in `ios.patch` (applied automatically by the
 makefile via `git apply` before `autoreconf`). Same surface as the
 3.1 patch, since iOS makes the same things unavailable in both:
 
-### 1. `configure.ac` — Remove DYLD_INSERT_LIBRARIES
+### 1. `configure.ac`: Remove DYLD_INSERT_LIBRARIES
 
 The line `: ${PRELOADENV=DYLD_INSERT_LIBRARIES}` is deleted. iOS doesn't
 support `DYLD_INSERT_LIBRARIES`; referencing it causes configure
 warnings/failures.
 
-### 2. `dir.c` — sys/vnode.h iOS shim
+### 2. `dir.c`: sys/vnode.h iOS shim
 
 `<sys/vnode.h>` isn't part of the iOS SDK. Under `TARGET_OS_IPHONE`, the
 include is skipped and the required constants are hardcoded:
@@ -42,7 +42,7 @@ include is skipped and the required constants are hardcoded:
 
 macOS still uses the original `#include <sys/vnode.h>`.
 
-### 3. `process.c` — `system()` disabled on iOS
+### 3. `process.c`: `system()` disabled on iOS
 
 iOS sandboxing disallows `system()`. In `rb_spawn_process()`, the call
 is stubbed:
@@ -96,5 +96,5 @@ cross_compiling=yes
 
 ### Output
 
-- `libruby.3.0-static.a` — copied into `$(LIBDIR)`
+- `libruby.3.0-static.a`: copied into `$(LIBDIR)`
 - Headers installed to `$(INCLUDEDIR)/ruby-3.0.0/`

--- a/ios/Dependencies/ruby31/PATCHES.md
+++ b/ios/Dependencies/ruby31/PATCHES.md
@@ -1,34 +1,34 @@
-# Ruby 3.1 — Patches & Build Notes
+# Ruby 3.1: Patches & Build Notes
 
 ## Source
 
 - **Upstream**: Ruby 3.1.3
 - **Fork**: <https://github.com/mkxp-z/ruby> branch `mkxp-z-3.1.3`
   (submodule at `sources/ruby`)
-- **Base commit**: `4d85560` (Nobuyoshi Nakada — "Fix redefinition of
+- **Base commit**: `4d85560` (Nobuyoshi Nakada: "Fix redefinition of
   `clock_gettime` and `clock_getres`")
 
 ## Why Ruby 3.1?
 
-Modern mkxp-z forks (Pokemon Reborn 19+, Vanguard, Flux, Infinite
-Fusion) target Ruby 3.x. Ruby 3.1 is also the only Empo build with
-the syntax-transform patches enabled (see `docs/multi-ruby.md`,
-"Syntax transform stays"), so mixed-grammar Pokemon Essentials forks
-(Vinemon Sauce Edition, etc.) that combine 1.8-era syntax with 1.9+
-runtime methods route here in LEGACY transform mode.
+Modern Pokemon Essentials forks built on the mkxp-z runtime target
+Ruby 3.x. Ruby 3.1 is also the only Empo build with the syntax-
+transform patches enabled (see `docs/multi-ruby.md`, "Syntax transform
+stays"), so mixed-grammar Pokemon Essentials forks that combine
+1.8-era syntax with 1.9+ runtime methods route here in LEGACY transform
+mode.
 
 ## Patches
 
 All iOS patches are in `ios.patch` (applied automatically by the makefile
 via `git apply` before `autoreconf`):
 
-### 1. `configure.ac` — Remove DYLD_INSERT_LIBRARIES
+### 1. `configure.ac`: Remove DYLD_INSERT_LIBRARIES
 
 The line `: ${PRELOADENV=DYLD_INSERT_LIBRARIES}` is deleted. On iOS,
 `DYLD_INSERT_LIBRARIES` is not supported, and referencing it causes
 configure warnings/failures.
 
-### 2. `dir.c` — sys/vnode.h iOS shim
+### 2. `dir.c`: sys/vnode.h iOS shim
 
 `<sys/vnode.h>` is not available in the iOS SDK. When `TARGET_OS_IPHONE`
 is true, the header include is skipped and the required constants are
@@ -44,7 +44,7 @@ hardcoded:
 
 On macOS, the original `#include <sys/vnode.h>` is used as before.
 
-### 3. `process.c` — system() disabled on iOS
+### 3. `process.c`: system() disabled on iOS
 
 The `system()` C library call is not available on iOS (sandboxing
 restrictions). In `rb_spawn_process()`, the call is stubbed out:
@@ -101,5 +101,5 @@ cross_compiling=yes
 
 ### Output
 
-- `libruby.3.1-static.a` — manually copied into `$(LIBDIR)`
+- `libruby.3.1-static.a`: manually copied into `$(LIBDIR)`
 - Headers installed to `$(INCLUDEDIR)/ruby-3.1.0/`

--- a/ios/Dependencies/sdl2/PATCHES.md
+++ b/ios/Dependencies/sdl2/PATCHES.md
@@ -1,4 +1,4 @@
-# SDL2 — Patches & Build Notes
+# SDL2: Patches & Build Notes
 
 ## Source
 
@@ -10,9 +10,9 @@
 
 Three custom commits on top of upstream SDL 2.28.1:
 
-1. **`07550ddbf`** (Struma) — Remove `-mwindows` linker flag
-2. **`5042c1559`** (Struma) — Disable NEON, fix loading ANGLE on macOS
-3. **`d3ac4c374`** (Splendide Imaginarius) — Disable NEON in `SDL_stretch.c`
+1. **`07550ddbf`** (Struma): Remove `-mwindows` linker flag
+2. **`5042c1559`** (Struma): Disable NEON, fix loading ANGLE on macOS
+3. **`d3ac4c374`** (Splendide Imaginarius): Disable NEON in `SDL_stretch.c`
 
 The NEON patches prevent build/runtime issues on ARM platforms where the
 NEON intrinsics cause problems with the cross-compilation toolchain.
@@ -34,7 +34,7 @@ cmake .. \
 Key flags:
 
 - Desktop OpenGL disabled (`SDL_OPENGL=OFF`)
-- OpenGL ES enabled (`SDL_OPENGLES=ON`) — the rendering backend used by mkxp-z on iOS
+- OpenGL ES enabled (`SDL_OPENGLES=ON`): the rendering backend used by mkxp-z on iOS
 - Metal enabled for SDL's internal use
 
 Common cross-compilation flags are inherited from `common.make` (sysroot,

--- a/ios/Dependencies/sdl2_image/PATCHES.md
+++ b/ios/Dependencies/sdl2_image/PATCHES.md
@@ -1,10 +1,10 @@
-# SDL2_image — Patches & Build Notes
+# SDL2_image: Patches & Build Notes
 
 ## Source
 
 - **Upstream**: SDL_image ~2.6.3 (`release-2.6.0` tag + 18 upstream commits)
 - **Fork**: <https://github.com/mkxp-z/SDL_image> branch `mkxp-z`
-- **Top commit**: `d3c6d59` (Sam Lantinga — "Fixed Xcode DYLIB_CURRENT_VERSION")
+- **Top commit**: `d3c6d59` (Sam Lantinga: "Fixed Xcode DYLIB_CURRENT_VERSION")
 
 ## Patches
 
@@ -32,7 +32,7 @@ cmake .. \
 Key flags:
 
 - Static build with vendored sub-dependencies (libjpeg, etc.)
-- Apple ImageIO backend disabled — uses vendored decoders instead
+- Apple ImageIO backend disabled: uses vendored decoders instead
 - JPEG XL support disabled
 - After cloning, `./external/download.sh` is run to fetch vendored sources
 

--- a/ios/Dependencies/sdl2_ttf/PATCHES.md
+++ b/ios/Dependencies/sdl2_ttf/PATCHES.md
@@ -1,4 +1,4 @@
-# SDL2_ttf — Patches & Build Notes
+# SDL2_ttf: Patches & Build Notes
 
 ## Source
 
@@ -10,9 +10,9 @@
 
 Two custom commits on top of upstream:
 
-1. **`20e405a`** (Roza) — Do not need test programs
+1. **`20e405a`** (Roza): Do not need test programs
    - Removes test program compilation from the build.
-2. **`0d5909e`** (Roza) — Disable NEON so it builds on ARM
+2. **`0d5909e`** (Roza): Disable NEON so it builds on ARM
    - Prevents NEON intrinsic issues during cross-compilation for ARM platforms.
 
 ## iOS Build Instructions

--- a/ios/Dependencies/sdl_sound/PATCHES.md
+++ b/ios/Dependencies/sdl_sound/PATCHES.md
@@ -1,4 +1,4 @@
-# SDL_sound — Patches & Build Notes
+# SDL_sound: Patches & Build Notes
 
 ## Source
 
@@ -10,7 +10,7 @@
 
 One custom commit on top of upstream:
 
-1. **`cfb2533`** (Struma) — Build properly on macOS
+1. **`cfb2533`** (Struma): Build properly on macOS
    - Fixes a build issue specific to macOS/Darwin toolchains.
 
 ## iOS Build Instructions
@@ -27,7 +27,7 @@ cmake .. \
 
 Key flags:
 
-- CoreAudio decoder disabled — uses Vorbis/Ogg decoders instead
+- CoreAudio decoder disabled: uses Vorbis/Ogg decoders instead
 - Test programs disabled
 
 Depends on: SDL2, libogg, libvorbis

--- a/ios/Empo/src/Library/GameLoadingView.swift
+++ b/ios/Empo/src/Library/GameLoadingView.swift
@@ -25,7 +25,7 @@ struct GameLoadingView: View {
     /// Cancel button is revealed so the user can bail if a game hangs during
     /// boot (common with broken Win32 DLL dependencies or bad scripts).
     @State private var cancelVisible = false
-    private static let cancelAppearDelay: Duration = .seconds(2)
+    private static let cancelAppearDelay: Duration = .seconds(7)
 
     /// Looked up at body-time so the loading view shares the same
     /// source image as the Game Info sheet's banner. By design


### PR DESCRIPTION
End-to-end audit of every tracked .md file across the three repos: super (this repo), engine, hmode7. Plus one small UX fix.

## Specific game titles removed

Across all README, docs, and PATCHES files. Generalized to \"RPG Maker XP fan games\" or \"Pokemon Essentials forks\" where context calls for it. Pokemon Essentials kept since it's a toolkit, not a game title.

## Stale facts corrected

- Drop simulator-rotation \"limitation\" from the README. That crash was on the legacy EAGL path; the engine runs on ANGLE now.
- Reframe the README's Notable hacks so multi-Ruby leads. The previous \"Syntax transform on Ruby 3.1 only\" framing implied Ruby 3.1 was the whole story.
- Bump the engine submodule to [PR #13](https://github.com/mateo-m/mkxp-z-apple-mobile/pull/13) which carries the engine README rewrite + hmode7 advance to [PR #5](https://github.com/mateo-m/hmode7-apple-mobile/pull/5).

## Syntax transform documentation expanded

\`docs/multi-ruby.md\`'s Syntax transform section now answers all three of: why it exists (mixed-grammar Pokemon Essentials forks combine 1.8 syntax with 1.9+ runtime methods, no single interpreter handles both), why only Ruby 3.1 carries the patches (other versions parse their native grammar fine via multi-Ruby native dispatch), and when each mode activates (table mapping \`useModernRuby\` × Ruby version to the bridge's \`SyntaxTransformMode\` enum).

## UX fix: stuck-loading message delay

\`GameLoadingView\`'s \"if loading is stuck, close Empo from the app switcher\" message now waits 7 seconds instead of 2. The previous 2s was firing during normal cold-start imports of large games (multi-Ruby selection + script load takes a moment) and presenting a scary alert during routine load. 7s sits past the 95th percentile of legitimate load times observed locally.

## Files changed

\`README.md\`, \`docs/multi-ruby.md\`, \`docs/multi-session.md\`, all 9 \`ios/Dependencies/*/PATCHES.md\`, \`ios/Empo/src/Library/GameLoadingView.swift\`, plus the engine submodule pointer.