### PR TITLE
docs: empo etymology + syntax-transform cross-ref + engine bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Empo wraps the [mkxp-z](https://github.com/mkxp-z/mkxp-z) RPG Maker engine in a native SwiftUI library and a customizable touch-controls overlay. RPG Maker XP / VX / VX Ace games and modern Pokemon Essentials forks run on-device, no desktop emulator needed.
 
+The name's from *emporos*, ancient Greek for a traveler riding on someone else's ship. Empo's the ship.
+
 ## Table of Contents
 
 - [Highlights](#highlights)

--- a/docs/multi-ruby.md
+++ b/docs/multi-ruby.md
@@ -17,7 +17,7 @@ Different RPG Maker generations target different Ruby versions:
 | RGSS3 (RPG Maker VX Ace) | `RGSS300.dll` | 1.9 | Traditional VX Ace games |
 | mkxp-z modern | bundled `x64-msvcrt-rubyXYZ.dll` | 3.0 / 3.1 | Modern Pokemon Essentials forks shipping the mkxp-z runtime |
 
-A single Ruby version that tries to cover all of these is fragile. Ruby 1.8 can't parse modern code (keyword args, safe nav, pattern matching). Ruby 3.x can't parse a lot of vintage code (`when X:`, character literal arithmetic, removed `Object#id`). Source-rewrite hacks like the syntax-transform patches make 3.1 accept some 1.8 grammar but break in subtle ways for genuinely modern games (see "Syntax transform stays" below).
+A single Ruby version that tries to cover all of these is fragile. Ruby 1.8 can't parse modern code (keyword args, safe nav, pattern matching). Ruby 3.x can't parse a lot of vintage code (`when X:`, character literal arithmetic, removed `Object#id`). Source-rewrite hacks like the syntax-transform patches make 3.1 accept some 1.8 grammar but break in subtle ways for genuinely modern games (see [Syntax transform](#syntax-transform) below).
 
 Running each game on its actual native Ruby is the only honest fix.
 


### PR DESCRIPTION
Three small things:

- Add a one-line etymology note to the README. Empo is from Greek *emporos*, a traveler riding on someone else's ship. Short on purpose.
- Fix the dangling cross-reference in `docs/multi-ruby.md`. The earlier audit pass renamed the section from "Syntax transform stays" to "Syntax transform" but left the in-doc link pointing at the old anchor (Copilot caught it).
- Bump engine submodule to [PR #14](https://github.com/mateo-m/mkxp-z-apple-mobile/pull/14): drop dangling HMODE7_PORT_DESIGN.md refs in shim + binding, bump hmode7 to [PR #6](https://github.com/mateo-m/hmode7-apple-mobile/pull/6) which dropped the design doc itself.