### PR TITLE
chore: silence submodule-dirty noise

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,11 +40,14 @@
 [submodule "ios/Dependencies/sources/openal-soft"]
 	path = ios/Dependencies/sources/openal-soft
 	url = https://github.com/kcat/openal-soft.git
+	ignore = dirty
 [submodule "ios/Dependencies/sources/ruby30"]
 	path = ios/Dependencies/sources/ruby30
 	url = https://github.com/ruby/ruby.git
 	branch = ruby_3_0
+	ignore = dirty
 [submodule "ios/Dependencies/sources/ruby19"]
 	path = ios/Dependencies/sources/ruby19
 	url = https://github.com/ruby/ruby.git
 	branch = ruby_1_9_3
+	ignore = dirty


### PR DESCRIPTION
openal-soft, ruby19, and ruby30 submodule entries lacked `ignore = dirty` while sibling dependency submodules had it. The dirty state comes from the build's `git apply` of `ios.patch` against the submodule tree, which is by design (patches live as a single .patch file rather than committed submodule changes). The dirty status was spamming `git status` output for no reason.