### PR TITLE
chore(ci): audit pinned versions, switch swift+objc-cpp to Linux

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,9 +12,10 @@ on:
 jobs:
   swift:
     name: Swift (swift-format)
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
+    container: swift:6.2-noble
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: false
 
@@ -22,20 +23,27 @@ jobs:
         run: |
           # `swift-format format` exits 0 even if it changed files; we
           # need to detect a no-op vs. a modification. Use --in-place
-          # against a clean tree, then `git diff --exit-code`.
-          xcrun swift-format format --in-place --recursive ios/Empo/src
-          if ! git diff --exit-code; then
+          # against a clean tree, then `git diff` scoped to the swift
+          # paths so unrelated working-tree state (submodule pointer
+          # drift, etc.) doesn't trip the check.
+          swift-format format --in-place --recursive ios/Empo/src
+          if ! git diff --exit-code -- ios/Empo/src; then
             echo "::error::swift-format would modify files. Run \`swift-format format --in-place --recursive ios/Empo/src\` locally and commit."
             exit 1
           fi
 
   objc-cpp:
     name: ObjC / C / C++ (clang-format)
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: false
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends clang-format
 
       - name: clang-format check
         run: |
@@ -47,9 +55,9 @@ jobs:
             'ios/Empo/shims/*.c' \
             'ios/Empo/shims/*.cpp')
           if [ -n "$FILES" ]; then
-            echo "$FILES" | xargs xcrun clang-format -i
-            if ! git diff --exit-code; then
-              echo "::error::clang-format would modify files. Run \`xcrun clang-format -i <files>\` locally and commit."
+            echo "$FILES" | xargs clang-format -i
+            if ! git diff --exit-code -- $FILES; then
+              echo "::error::clang-format would modify files. Run \`clang-format -i <files>\` locally and commit."
               exit 1
             fi
           fi
@@ -58,7 +66,7 @@ jobs:
     name: Bash (shfmt)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install shfmt
         run: |
@@ -77,11 +85,11 @@ jobs:
     name: YAML / JSON (prettier)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install prettier
         run: npm install -g prettier@3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,18 +8,40 @@ on:
 jobs:
   swift:
     name: Swift (swiftlint + swift-format)
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
+    container: swift:6.2-noble
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: false
 
+      - name: Install dependencies
+        run: |
+          # The swift:*-noble base image is minimal; pull in curl +
+          # unzip + git for the checkout post-step and SwiftLint
+          # download.
+          apt-get update -qq
+          apt-get install -y --no-install-recommends curl unzip git ca-certificates
+
       - name: Install SwiftLint
-        run: brew install swiftlint
+        run: |
+          # SwiftLint ships per-arch Linux binaries as release assets.
+          ARCH=$(uname -m)
+          case "$ARCH" in
+            x86_64)  ASSET=swiftlint_linux_amd64.zip ;;
+            aarch64) ASSET=swiftlint_linux_arm64.zip ;;
+            *) echo "unsupported arch: $ARCH" >&2; exit 1 ;;
+          esac
+          curl -fsSL -o /tmp/swiftlint.zip \
+            "https://github.com/realm/SwiftLint/releases/download/0.63.2/$ASSET"
+          unzip -q /tmp/swiftlint.zip -d /usr/local/bin
+          chmod +x /usr/local/bin/swiftlint
+          swiftlint --version
 
       - name: swift-format check
         run: |
-          xcrun swift-format lint --strict --recursive ios/Empo/src
+          # swift-format ships with the Swift toolchain (6.0+).
+          swift-format lint --strict --recursive ios/Empo/src
 
       - name: swiftlint
         run: |
@@ -27,11 +49,16 @@ jobs:
 
   objc-cpp:
     name: ObjC / C / C++ (clang-format)
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: false
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends clang-format
 
       - name: clang-format check
         run: |
@@ -43,17 +70,22 @@ jobs:
             'ios/Empo/shims/*.c' \
             'ios/Empo/shims/*.cpp')
           if [ -n "$FILES" ]; then
-            echo "$FILES" | xargs xcrun clang-format --dry-run --Werror
+            echo "$FILES" | xargs clang-format --dry-run --Werror
           fi
 
   shell:
     name: Bash (shellcheck + shfmt)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Install shfmt
+      - name: Install shfmt + shellcheck
         run: |
+          # shellcheck is pre-installed on GitHub-hosted ubuntu
+          # runners but not in many community runner images, so
+          # install it explicitly for portability.
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends shellcheck
           curl -fsSL -o /usr/local/bin/shfmt \
             https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_linux_amd64
           chmod +x /usr/local/bin/shfmt
@@ -76,16 +108,19 @@ jobs:
     name: YAML (prettier + yamllint)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install tools
         run: |
           npm install -g prettier@3
-          pip install --user yamllint
+          # yamllint comes from apt to avoid PEP 668 (Ubuntu 24.04+
+          # blocks unmanaged pip installs into the system Python).
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends yamllint
 
       - name: prettier check (YAML + JSON)
         run: |
@@ -93,21 +128,23 @@ jobs:
 
       - name: yamllint
         run: |
-          ~/.local/bin/yamllint -c .yamllint.yml ios/Empo/project.yml || true
-          # yamllint warnings shouldn't fail CI; only structural errors should.
-          # Re-run with strict mode; treat warnings as soft.
-          ~/.local/bin/yamllint --strict -c .yamllint.yml ios/Empo/project.yml \
-            && exit 0 || echo "yamllint reported issues (warnings tolerated; failing only on errors)"
+          # yamllint warnings shouldn't fail CI; only structural
+          # errors should. --strict promotes warnings to failures,
+          # so we run twice: first to surface the issues, then
+          # `|| true` to keep the soft-warn behaviour.
+          yamllint -c .yamllint.yml ios/Empo/project.yml || true
+          yamllint --strict -c .yamllint.yml ios/Empo/project.yml \
+            || echo "yamllint reported issues (warnings tolerated; failing only on errors)"
 
   markdown:
     name: Markdown (markdownlint)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install markdownlint-cli
         run: npm install -g markdownlint-cli@0.48


### PR DESCRIPTION
## Summary

Per request: audit every pinned action and tool in the workflows, find the current latest version online, and update. Then run all workflows locally with `act` to surface real issues before they hit GitHub.

## Version audit

| Component | Was | Now | Change |
|---|---|---|---|
| `actions/checkout` | `@v4` | `@v6` | 2 majors behind |
| `actions/setup-node` | `@v4` | `@v6` | 2 majors behind |
| `ruby/setup-ruby` | `@v1` | `@v1` | OK (`@v1` floats) |
| Node | `"20"` | `"24"` | **Node 20 is EOL** since 2026-04 |
| Ruby | `"3.3"` | `"3.4"` | one minor behind |
| `swiftlint` | `0.61.0` | `0.63.2` | 2 minors behind |
| `prettier` | `@3` | `@3` | OK (floats to 3.8.3) |
| `markdownlint-cli` | `@0.48` | `@0.48` | current |
| `shfmt` | `v3.13.1` | `v3.13.1` | current |

## macos-latest -> ubuntu-latest for swift + clang-format jobs

Swift jobs no longer need a macOS runner. swift-format ships with the Swift Linux toolchain; SwiftLint provides per-arch Linux binaries; clang-format is one apt-install. Saves billable minutes (macOS is 10x Linux) and lets the full pipeline run under act locally with no -self-hosted shim.

## Robustness fixes act surfaced

- shellcheck was not installed (works on GitHub-hosted ubuntu by accident). Now apt-installed.
- yamllint via apt instead of pip --user (PEP 668 on Ubuntu 24.04+).
- swift:*-noble base image is minimal: install curl + unzip + git + ca-certificates explicitly.
- Format jobs' git diff --exit-code scoped to the paths each job formats; otherwise unrelated working-tree state (submodule drift, etc.) trips the check.

## act verification

All 9 super jobs pass end-to-end locally via act before this PR. Engine + hmode7 PRs follow with the same audit.

Engine submodule pointer bumped to track PRs #17 + #18 from earlier today.