### PR TITLE
fix(ci): install git BEFORE actions/checkout in swift container

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,6 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     container: swift:6.2-noble
     steps:
+      - name: Install git (pre-checkout)
+        run: |
+          # The swift:*-noble base image is minimal. actions/checkout
+          # falls back to a tarball download (no .git) when git is
+          # missing inside the container; install it first so the
+          # `git diff --exit-code` step downstream has a real repo.
+          apt-get update -qq
+          apt-get install -y --no-install-recommends git ca-certificates
+
       - uses: actions/checkout@v6
         with:
           submodules: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,17 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     container: swift:6.2-noble
     steps:
+      - name: Install dependencies (pre-checkout)
+        run: |
+          # The swift:*-noble base image is minimal. actions/checkout
+          # falls back to a tarball download (no .git) when git is
+          # missing inside the container, which then breaks every
+          # `git`-driven step downstream. Install git BEFORE the
+          # checkout step so a real .git directory lands on disk.
+          apt-get update -qq
+          apt-get install -y --no-install-recommends git curl unzip ca-certificates
+
       - uses: actions/checkout@v6
         with:
           submodules: false
-
-      - name: Install dependencies
-        run: |
-          # The swift:*-noble base image is minimal; pull in curl +
-          # unzip + git for the checkout post-step and SwiftLint
-          # download.
-          apt-get update -qq
-          apt-get install -y --no-install-recommends curl unzip git ca-certificates
 
       - name: Install SwiftLint
         run: |


### PR DESCRIPTION
Real-CI failure caught after #53 landed.

`actions/checkout@v6` inside a minimal container without git falls back to a REST-API tarball download. Files land on disk but `.git` does not. `git diff --exit-code` in the swift-format step then fails with 'Not a git repository' and dumps the diff help banner.

Fix: install git via apt BEFORE actions/checkout in both lint.yml and format.yml swift jobs. The fallback path is never taken and a real .git directory lands as expected.

Verified locally with act before pushing.