### PR TITLE
fix(ci): resolve swiftly wrapper to real toolchain

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,11 +23,20 @@ jobs:
 
       - name: Locate sourcekitd for SwiftLint
         # SwiftLint on Linux loads `libsourcekitdInProc.so` from
-        # `LINUX_SOURCEKIT_LIB_PATH`. Swiftly installs the Swift
-        # toolchain under `$SWIFTLY_HOME_DIR/toolchains/...`; point
-        # SwiftLint at that lib dir.
+        # `LINUX_SOURCEKIT_LIB_PATH`. Swiftly's `bin/swift` is a
+        # wrapper into `toolchains/<version>/usr/bin/swift`; resolve
+        # the wrapper with `readlink -f` to land in the real toolchain
+        # so we can point SwiftLint at the matching `usr/lib`.
         run: |
-          SK_LIB=$(dirname "$(which swift)")/../lib
+          SWIFT_REAL=$(readlink -f "$(which swift)")
+          SK_LIB=$(dirname "$SWIFT_REAL")/../lib
+          echo "Resolved Swift toolchain at $SWIFT_REAL"
+          echo "Looking for libsourcekitdInProc.so under $SK_LIB"
+          ls -la "$SK_LIB/libsourcekitdInProc.so" || {
+            echo "::error::libsourcekitdInProc.so not at expected path; dumping toolchain layout for debug"
+            find "$SWIFTLY_HOME_DIR" -name 'libsourcekitdInProc.so' 2>/dev/null | head
+            exit 1
+          }
           echo "LINUX_SOURCEKIT_LIB_PATH=$SK_LIB" >> "$GITHUB_ENV"
 
       - name: swift-format lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,15 @@ jobs:
         with:
           toolchain: "6.2"
 
+      - name: Locate sourcekitd for SwiftLint
+        # SwiftLint on Linux loads `libsourcekitdInProc.so` from
+        # `LINUX_SOURCEKIT_LIB_PATH`. Swiftly installs the Swift
+        # toolchain under `$SWIFTLY_HOME_DIR/toolchains/...`; point
+        # SwiftLint at that lib dir.
+        run: |
+          SK_LIB=$(dirname "$(which swift)")/../lib
+          echo "LINUX_SOURCEKIT_LIB_PATH=$SK_LIB" >> "$GITHUB_ENV"
+
       - name: swift-format lint
         run: swift-format lint --strict --recursive ios/Empo/src
 


### PR DESCRIPTION
PR #56 set `LINUX_SOURCEKIT_LIB_PATH` to swiftly's top-level `bin/../lib` (which is empty). The actual sourcekitd lib lives one toolchain deep. `readlink -f $(which swift)` resolves the wrapper to the real toolchain binary so we can point at the matching `usr/lib`.