### PR TITLE
fix(ci): find sourcekitd by walking swiftly toolchains dir

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,20 +23,18 @@ jobs:
 
       - name: Locate sourcekitd for SwiftLint
         # SwiftLint on Linux loads `libsourcekitdInProc.so` from
-        # `LINUX_SOURCEKIT_LIB_PATH`. Swiftly's `bin/swift` is a
-        # wrapper into `toolchains/<version>/usr/bin/swift`; resolve
-        # the wrapper with `readlink -f` to land in the real toolchain
-        # so we can point SwiftLint at the matching `usr/lib`.
+        # `LINUX_SOURCEKIT_LIB_PATH`. The `swift` binary on PATH is
+        # actually swiftly's manager, not the toolchain's swift, so
+        # `which swift` doesn't help. Locate the lib directly under
+        # `$SWIFTLY_HOME_DIR/toolchains/<version>/usr/lib/`.
         run: |
-          SWIFT_REAL=$(readlink -f "$(which swift)")
-          SK_LIB=$(dirname "$SWIFT_REAL")/../lib
-          echo "Resolved Swift toolchain at $SWIFT_REAL"
-          echo "Looking for libsourcekitdInProc.so under $SK_LIB"
-          ls -la "$SK_LIB/libsourcekitdInProc.so" || {
-            echo "::error::libsourcekitdInProc.so not at expected path; dumping toolchain layout for debug"
-            find "$SWIFTLY_HOME_DIR" -name 'libsourcekitdInProc.so' 2>/dev/null | head
+          SK_LIB_FILE=$(find "$SWIFTLY_HOME_DIR/toolchains" -name 'libsourcekitdInProc.so' 2>/dev/null | head -1)
+          if [ -z "$SK_LIB_FILE" ]; then
+            echo "::error::libsourcekitdInProc.so not found under $SWIFTLY_HOME_DIR"
             exit 1
-          }
+          fi
+          SK_LIB=$(dirname "$SK_LIB_FILE")
+          echo "Found sourcekitd at $SK_LIB_FILE"
           echo "LINUX_SOURCEKIT_LIB_PATH=$SK_LIB" >> "$GITHUB_ENV"
 
       - name: swift-format lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,11 +23,20 @@ jobs:
 
       - name: Locate sourcekitd for SwiftLint
         # SwiftLint on Linux loads `libsourcekitdInProc.so` from
-        # `LINUX_SOURCEKIT_LIB_PATH`. Swiftly installs the Swift
-        # toolchain under `$SWIFTLY_HOME_DIR/toolchains/...`; point
-        # SwiftLint at that lib dir.
+        # `LINUX_SOURCEKIT_LIB_PATH`. Swiftly's `bin/swift` is a
+        # wrapper into `toolchains/<version>/usr/bin/swift`; resolve
+        # the wrapper with `readlink -f` to land in the real toolchain
+        # so we can point SwiftLint at the matching `usr/lib`.
         run: |
-          SK_LIB=$(dirname "$(which swift)")/../lib
+          SWIFT_REAL=$(readlink -f "$(which swift)")
+          SK_LIB=$(dirname "$SWIFT_REAL")/../lib
+          echo "Resolved Swift toolchain at $SWIFT_REAL"
+          echo "Looking for libsourcekitdInProc.so under $SK_LIB"
+          ls -la "$SK_LIB/libsourcekitdInProc.so" || {
+            echo "::error::libsourcekitdInProc.so not at expected path; dumping toolchain layout for debug"
+            find "$SWIFTLY_HOME_DIR" -name 'libsourcekitdInProc.so' 2>/dev/null | head
+            exit 1
+          }
           echo "LINUX_SOURCEKIT_LIB_PATH=$SK_LIB" >> "$GITHUB_ENV"
 
       - name: swift-format lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,15 @@ jobs:
         with:
           toolchain: "6.2"
 
+      - name: Locate sourcekitd for SwiftLint
+        # SwiftLint on Linux loads `libsourcekitdInProc.so` from
+        # `LINUX_SOURCEKIT_LIB_PATH`. Swiftly installs the Swift
+        # toolchain under `$SWIFTLY_HOME_DIR/toolchains/...`; point
+        # SwiftLint at that lib dir.
+        run: |
+          SK_LIB=$(dirname "$(which swift)")/../lib
+          echo "LINUX_SOURCEKIT_LIB_PATH=$SK_LIB" >> "$GITHUB_ENV"
+
       - name: swift-format lint
         run: swift-format lint --strict --recursive ios/Empo/src
 


### PR DESCRIPTION
PR #57's `readlink -f $(which swift)` resolved to `/swiftly/bin/swiftly` (the manager, not the toolchain's swift). The lib is at `$SWIFTLY_HOME_DIR/toolchains/<version>/usr/lib/libsourcekitdInProc.so`; `find` locates it directly. Confirmed via the debug dump in PR #57's failure.