### PR TITLE
chore(ci): cache Swift toolchain across runs

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,6 +18,13 @@ jobs:
         with:
           submodules: false
 
+      - name: Cache Swift toolchain
+        id: cache-swift
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/swiftly
+          key: swiftly-${{ runner.os }}-6.2
+
       - name: Install Swift toolchain
         uses: vapor/swiftly-action@v0.2
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,9 +14,18 @@ jobs:
         with:
           submodules: false
 
+      - name: Cache Swift toolchain
+        id: cache-swift
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/swiftly
+          key: swiftly-${{ runner.os }}-6.2
+
       - name: Install Swift toolchain
         # Swiftly is Apple's official toolchain manager. Gives us
         # swift-format on ubuntu-latest without a custom container.
+        # On cache hit the action detects the existing toolchain and
+        # short-circuits the slow download.
         uses: vapor/swiftly-action@v0.2
         with:
           toolchain: "6.2"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,20 +23,18 @@ jobs:
 
       - name: Locate sourcekitd for SwiftLint
         # SwiftLint on Linux loads `libsourcekitdInProc.so` from
-        # `LINUX_SOURCEKIT_LIB_PATH`. Swiftly's `bin/swift` is a
-        # wrapper into `toolchains/<version>/usr/bin/swift`; resolve
-        # the wrapper with `readlink -f` to land in the real toolchain
-        # so we can point SwiftLint at the matching `usr/lib`.
+        # `LINUX_SOURCEKIT_LIB_PATH`. The `swift` binary on PATH is
+        # actually swiftly's manager, not the toolchain's swift, so
+        # `which swift` doesn't help. Locate the lib directly under
+        # `$SWIFTLY_HOME_DIR/toolchains/<version>/usr/lib/`.
         run: |
-          SWIFT_REAL=$(readlink -f "$(which swift)")
-          SK_LIB=$(dirname "$SWIFT_REAL")/../lib
-          echo "Resolved Swift toolchain at $SWIFT_REAL"
-          echo "Looking for libsourcekitdInProc.so under $SK_LIB"
-          ls -la "$SK_LIB/libsourcekitdInProc.so" || {
-            echo "::error::libsourcekitdInProc.so not at expected path; dumping toolchain layout for debug"
-            find "$SWIFTLY_HOME_DIR" -name 'libsourcekitdInProc.so' 2>/dev/null | head
+          SK_LIB_FILE=$(find "$SWIFTLY_HOME_DIR/toolchains" -name 'libsourcekitdInProc.so' 2>/dev/null | head -1)
+          if [ -z "$SK_LIB_FILE" ]; then
+            echo "::error::libsourcekitdInProc.so not found under $SWIFTLY_HOME_DIR"
             exit 1
-          }
+          fi
+          SK_LIB=$(dirname "$SK_LIB_FILE")
+          echo "Found sourcekitd at $SK_LIB_FILE"
           echo "LINUX_SOURCEKIT_LIB_PATH=$SK_LIB" >> "$GITHUB_ENV"
 
       - name: swift-format lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,11 +23,20 @@ jobs:
 
       - name: Locate sourcekitd for SwiftLint
         # SwiftLint on Linux loads `libsourcekitdInProc.so` from
-        # `LINUX_SOURCEKIT_LIB_PATH`. Swiftly installs the Swift
-        # toolchain under `$SWIFTLY_HOME_DIR/toolchains/...`; point
-        # SwiftLint at that lib dir.
+        # `LINUX_SOURCEKIT_LIB_PATH`. Swiftly's `bin/swift` is a
+        # wrapper into `toolchains/<version>/usr/bin/swift`; resolve
+        # the wrapper with `readlink -f` to land in the real toolchain
+        # so we can point SwiftLint at the matching `usr/lib`.
         run: |
-          SK_LIB=$(dirname "$(which swift)")/../lib
+          SWIFT_REAL=$(readlink -f "$(which swift)")
+          SK_LIB=$(dirname "$SWIFT_REAL")/../lib
+          echo "Resolved Swift toolchain at $SWIFT_REAL"
+          echo "Looking for libsourcekitdInProc.so under $SK_LIB"
+          ls -la "$SK_LIB/libsourcekitdInProc.so" || {
+            echo "::error::libsourcekitdInProc.so not at expected path; dumping toolchain layout for debug"
+            find "$SWIFTLY_HOME_DIR" -name 'libsourcekitdInProc.so' 2>/dev/null | head
+            exit 1
+          }
           echo "LINUX_SOURCEKIT_LIB_PATH=$SK_LIB" >> "$GITHUB_ENV"
 
       - name: swift-format lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,15 @@ jobs:
         with:
           toolchain: "6.2"
 
+      - name: Locate sourcekitd for SwiftLint
+        # SwiftLint on Linux loads `libsourcekitdInProc.so` from
+        # `LINUX_SOURCEKIT_LIB_PATH`. Swiftly installs the Swift
+        # toolchain under `$SWIFTLY_HOME_DIR/toolchains/...`; point
+        # SwiftLint at that lib dir.
+        run: |
+          SK_LIB=$(dirname "$(which swift)")/../lib
+          echo "LINUX_SOURCEKIT_LIB_PATH=$SK_LIB" >> "$GITHUB_ENV"
+
       - name: swift-format lint
         run: swift-format lint --strict --recursive ios/Empo/src
 


### PR DESCRIPTION
Add `actions/cache@v4` for `~/.local/share/swiftly` before `vapor/swiftly-action`. Saves ~40s per run after first warm-up.