### PR TITLE
chore(hooks): run mkxp-z rubocop in pre-push

### DIFF
--- a/scripts/hooks/pre-push.sh
+++ b/scripts/hooks/pre-push.sh
@@ -47,3 +47,16 @@ if ! git -C "$SUBMODULE_PATH" merge-base --is-ancestor "$SUBMODULE_SHA" "origin/
     printf 'Push or merge the submodule branch first, then push the parent repo.\n' >&2
     exit 1
 fi
+
+if ! command -v bundle >/dev/null 2>&1; then
+    printf 'pre-push failed: bundle is required to lint %s compat scripts\n' "$SUBMODULE_PATH" >&2
+    exit 1
+fi
+
+printf '\n-> mkxp-z rubocop (scripts/preload, scripts/postload)\n'
+if ! git -C "$SUBMODULE_PATH" bundle exec rubocop scripts/preload scripts/postload; then
+    printf 'pre-push failed: mkxp-z rubocop failed\n' >&2
+    exit 1
+fi
+
+printf 'pre-push OK\n'

--- a/scripts/hooks/pre-push.sh
+++ b/scripts/hooks/pre-push.sh
@@ -54,7 +54,7 @@ if ! command -v bundle >/dev/null 2>&1; then
 fi
 
 printf '\n-> mkxp-z rubocop (scripts/preload, scripts/postload)\n'
-if ! git -C "$SUBMODULE_PATH" bundle exec rubocop scripts/preload scripts/postload; then
+if ! (cd "$SUBMODULE_PATH" && bundle exec rubocop scripts/preload scripts/postload); then
     printf 'pre-push failed: mkxp-z rubocop failed\n' >&2
     exit 1
 fi


### PR DESCRIPTION
## Summary
- Extend parent `pre-push` to run the same mkxp-z rubocop scope as CI (`scripts/preload`, `scripts/postload`) after existing gitlink checks

## Test plan
- [ ] `lefthook run pre-push` with clean mkxp-z checkout at committed pointer
- [ ] Confirm failure when rubocop offenses are introduced in compat scripts