### PR TITLE
refactor(ios): move library catalog queries to GameLibrary

### DIFF
--- a/ios/Empo/src/Library/GameLibrary.swift
+++ b/ios/Empo/src/Library/GameLibrary.swift
@@ -149,6 +149,43 @@ class GameLibrary {
         withAnimation { games[idx] = entry }
     }
 
+    /// Filtered + sorted catalog for the library grid/list. Reads
+    /// `games` so SwiftUI Observation tracks reloads.
+    func displayedCatalog(
+        search: String,
+        sort: LibrarySortOption,
+        sizes: [String: Int64]
+    ) -> [GameEntry] {
+        let base =
+            search.isEmpty
+            ? games
+            : games.filter { $0.title.localizedCaseInsensitiveContains(search) }
+        return sort.sort(base, sizes: sizes)
+    }
+
+    /// Pre-flight import placeholders shown above the catalog when
+    /// the library already has games.
+    func pendingValidationCatalog() -> [GameEntry] {
+        guard !games.isEmpty else { return [] }
+        return pendingImports.values
+            .sorted { $0.order < $1.order }
+            .map(\.syntheticEntry)
+    }
+
+    /// Hero card candidate for "Continue playing", or nil.
+    func recentlyPlayedCandidate(
+        showContinuePlaying: Bool,
+        searchText: String
+    ) -> GameEntry? {
+        guard showContinuePlaying, searchText.isEmpty else { return nil }
+        let readyGames = games.filter { $0.status == .ready }
+        guard readyGames.count > 1 else { return nil }
+        return
+            readyGames
+            .filter { $0.lastPlayed != nil }
+            .max(by: { ($0.lastPlayed ?? .distantPast) < ($1.lastPlayed ?? .distantPast) })
+    }
+
     func ensureGamesDirectory() {
         if !fm.fileExists(atPath: GameContainer.rootURL.path) {
             try? fm.createDirectory(at: GameContainer.rootURL, withIntermediateDirectories: true)

--- a/ios/Empo/src/Library/GameLibraryView.swift
+++ b/ios/Empo/src/Library/GameLibraryView.swift
@@ -7,6 +7,11 @@ private struct EmptyStateHeightKey: PreferenceKey {
     }
 }
 
+private struct CatalogAnimationKey: Equatable {
+    let id: String
+    let phase: GameStatus.Phase
+}
+
 struct GameLibraryView: View {
     var heroNamespace: Namespace.ID
     var splashDismissed: Bool = true
@@ -77,8 +82,8 @@ struct GameLibraryView: View {
         )
     }
 
-    private var catalogAnimationKey: [String] {
-        filteredGames.map { "\($0.id):\($0.status.phase)" }
+    private var catalogAnimationKey: [CatalogAnimationKey] {
+        filteredGames.map { CatalogAnimationKey(id: $0.id, phase: $0.status.phase) }
     }
 
     /// Synthetic cards for pre-flight validations, pinned to the top

--- a/ios/Empo/src/Library/GameLibraryView.swift
+++ b/ios/Empo/src/Library/GameLibraryView.swift
@@ -69,11 +69,15 @@ struct GameLibraryView: View {
     // is cheap; .map(\.id) in `.animation(value:)` was the actual
     // hot-loop offender and was dropped.
     private var filteredGames: [GameEntry] {
-        let base =
-            searchText.isEmpty
-            ? library.games
-            : library.games.filter { $0.title.localizedCaseInsensitiveContains(searchText) }
-        return settings.librarySortOption.sort(base, sizes: gameSizes)
+        library.displayedCatalog(
+            search: searchText,
+            sort: settings.librarySortOption,
+            sizes: gameSizes
+        )
+    }
+
+    private var catalogAnimationKey: [String] {
+        filteredGames.map { "\($0.id):\($0.status.phase)" }
     }
 
     /// Synthetic cards for pre-flight validations, pinned to the top
@@ -82,10 +86,7 @@ struct GameLibraryView: View {
     /// feedback on the Import button so the empty state doesn't
     /// bounce in and out on invalid imports.
     private var pendingValidationEntries: [GameEntry] {
-        guard !library.games.isEmpty else { return [] }
-        return library.pendingImports.values
-            .sorted { $0.order < $1.order }
-            .map(\.syntheticEntry)
+        library.pendingValidationCatalog()
     }
 
     private var showEmpty: Bool {
@@ -93,15 +94,10 @@ struct GameLibraryView: View {
     }
 
     private var recentlyPlayed: GameEntry? {
-        guard settings.showContinuePlaying else { return nil }
-        guard searchText.isEmpty else { return nil }
-        let readyGames = library.games.filter { $0.status == .ready }
-        guard readyGames.count > 1 else { return nil }  // no hero if only 1 game
-
-        return
-            readyGames
-            .filter { $0.lastPlayed != nil }
-            .max(by: { ($0.lastPlayed ?? .distantPast) < ($1.lastPlayed ?? .distantPast) })
+        library.recentlyPlayedCandidate(
+            showContinuePlaying: settings.showContinuePlaying,
+            searchText: searchText
+        )
     }
 
     @Environment(\.verticalSizeClass) private var verticalSizeClass
@@ -438,8 +434,8 @@ struct GameLibraryView: View {
         .padding(.horizontal)
         .padding(.top, Spacing.lg)
         .padding(.bottom)
-        .animation(Motion.standard, value: filteredGames)
-        .animation(Motion.standard, value: pendingValidationEntries)
+        .animation(Motion.standard, value: catalogAnimationKey)
+        .animation(Motion.standard, value: pendingValidationEntries.map(\.id))
     }
 
     private func heroCard(for game: GameEntry) -> some View {
@@ -529,8 +525,8 @@ struct GameLibraryView: View {
         }
         .padding(.horizontal)
         .padding(.top, Spacing.lg)
-        .animation(Motion.standard, value: filteredGames)
-        .animation(Motion.standard, value: pendingValidationEntries)
+        .animation(Motion.standard, value: catalogAnimationKey)
+        .animation(Motion.standard, value: pendingValidationEntries.map(\.id))
     }
 
     @ViewBuilder

--- a/ios/Empo/src/Library/GameLibraryView.swift
+++ b/ios/Empo/src/Library/GameLibraryView.swift
@@ -66,8 +66,9 @@ struct GameLibraryView: View {
     // entries stuck around after reload (an imported game stayed in
     // the progress state forever). Keeping it computed means it
     // tracks library.games directly. Filter + sort on 10s of entries
-    // is cheap; .map(\.id) in `.animation(value:)` was the actual
-    // hot-loop offender and was dropped.
+    // is cheap; animating on full `[GameEntry]` arrays (and their
+    // associated values like import progress) was the hot-loop
+    // offender. Lightweight id/phase keys replace those triggers.
     private var filteredGames: [GameEntry] {
         library.displayedCatalog(
             search: searchText,


### PR DESCRIPTION
## Summary
- Add `displayedCatalog`, `pendingValidationCatalog`, and `recentlyPlayedCandidate` on `GameLibrary` so filter/sort/hero logic lives with the catalog model
- Slim `GameLibraryView` to call those helpers and tighten animation triggers to id+phase keys instead of full `[GameEntry]` arrays

## Test plan
- [ ] Library grid/list updates when imports finish (no stale progress cards)
- [ ] Search and sort still work
- [ ] Continue-playing hero shows only when appropriate
- [ ] Pending validation cards appear above catalog when library is non-empty