### PR TITLE
refactor(ios): route player input through EngineSessionCoordinator

### DIFF
--- a/ios/Empo/src/App/EngineSessionCoordinator.swift
+++ b/ios/Empo/src/App/EngineSessionCoordinator.swift
@@ -28,6 +28,8 @@ final class EngineSessionCoordinator {
     private let sessionLogger = SessionLogger()
     private let termination = EngineTerminationCoordinator()
     private var terminationExpected = false
+    private var textInputModeHandler: ((Bool) -> Void)?
+    private var inputBridgesInstalled = false
 
     var pendingCrashRecovery: Bool { crashTracker.pendingCrashRecovery }
 
@@ -40,6 +42,7 @@ final class EngineSessionCoordinator {
             GameLibrary.shared.refreshGameEntry(id: gameID)
         }
         registerBridgeCallbacks()
+        installInputBridgesIfNeeded()
     }
 
     func consumeCrashRecovery() -> String? {
@@ -104,6 +107,39 @@ final class EngineSessionCoordinator {
 
     func restoreCrashMarker(for container: GameContainer) {
         crashTracker.writeMarker(for: container)
+    }
+
+    func setTextInputModeHandler(_ handler: @escaping (Bool) -> Void) {
+        textInputModeHandler = handler
+    }
+
+    func clearTextInputModeHandler() {
+        textInputModeHandler = nil
+    }
+
+    func injectKey(scancode: Int32, pressed: Bool) {
+        mkxp_injectKeyEvent(scancode, pressed ? 1 : 0)
+    }
+
+    func injectKeyTap(scancode: Int32, holdMilliseconds: Int = 50) {
+        injectKey(scancode: scancode, pressed: true)
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(holdMilliseconds))
+            injectKey(scancode: scancode, pressed: false)
+        }
+    }
+
+    private func installInputBridgesIfNeeded() {
+        guard !inputBridgesInstalled else { return }
+        inputBridgesInstalled = true
+
+        mkxp_setTextInputModeCallback(
+            { active, _ in
+                let on = active != 0
+                Task { @MainActor in
+                    EngineSessionCoordinator.shared.textInputModeHandler?(on)
+                }
+            }, nil)
     }
 
     private func registerBridgeCallbacks() {

--- a/ios/Empo/src/App/GameSession.swift
+++ b/ios/Empo/src/App/GameSession.swift
@@ -47,7 +47,7 @@ enum GameSession {
 
         let alignment = settings.verticalAlignment ?? GameConfigDefaults.engineVerticalAlignment
         let postload = settings.postloadScripts ?? GameConfigDefaults.enginePostloadScripts
-        let inGameKeyboardDefault = GameSettings.detectPokemonEssentials(
+        let inGameKeyboardDefault = PokemonEssentialsDetection.detect(
             in: gameDir,
             stateDirectory: stateDir
         )

--- a/ios/Empo/src/Library/EngineConfigProjector.swift
+++ b/ios/Empo/src/Library/EngineConfigProjector.swift
@@ -1,0 +1,104 @@
+import Foundation
+import GameProbe
+
+/// Merges `GameSettings` overrides into the per-game managed
+/// `EmpoState/mkxp.json` and reads developer defaults from
+/// `Game/mkxp.json`.
+enum EngineConfigProjector {
+    private static let configFilename = "mkxp.json"
+
+    static func readGameDefaults(from gameDirectory: URL) -> GameConfigDefaults {
+        let sourceURL = gameDirectory.appendingPathComponent(configFilename)
+
+        guard let raw = try? String(contentsOf: sourceURL, encoding: .utf8),
+            let config = parseJSONWithComments(raw)
+        else {
+            return GameConfigDefaults()
+        }
+
+        let enableHires = config["enableHires"] as? Bool ?? false
+        let scalingFactor =
+            (config["framebufferScalingFactor"] as? Double)
+            ?? (config["framebufferScalingFactor"] as? Int).map(Double.init)
+            ?? 1.0
+        let renderScale: RenderScale? =
+            if enableHires {
+                switch scalingFactor {
+                case ..<1.5: RenderScale.x1
+                case ..<3.0: RenderScale.x2
+                default: RenderScale.x4
+                }
+            } else {
+                nil
+            }
+
+        let solidFontsArray = config["solidFonts"] as? [String]
+        let solidFontsEnabled: Bool? = solidFontsArray.map { !$0.isEmpty }
+
+        return GameConfigDefaults(
+            smoothScaling: (config["smoothScaling"] as? Int).map { $0 != 0 },
+            fixedAspectRatio: config["fixedAspectRatio"] as? Bool,
+            renderScale: renderScale,
+            frameSkip: config["frameSkip"] as? Bool,
+            vsync: (config["syncToRefreshrate"] as? Bool)
+                ?? (config["vsync"] as? Bool),
+            pathCache: config["pathCache"] as? Bool,
+            fontScale: config["fontScale"] as? Double,
+            solidFonts: solidFontsEnabled
+        )
+    }
+
+    static func apply(
+        settings: GameSettings,
+        stateDirectory: URL,
+        gameDirectory: URL
+    ) {
+        let configURL = stateDirectory.appendingPathComponent(configFilename)
+        let sourceURL = gameDirectory.appendingPathComponent(configFilename)
+
+        var config: [String: Any] = [:]
+        if FileManager.default.fileExists(atPath: sourceURL.path),
+            let raw = try? String(contentsOf: sourceURL, encoding: .utf8),
+            let parsed = parseJSONWithComments(raw)
+        {
+            config = parsed
+        }
+
+        config.removeValue(forKey: "syntaxTransform")
+
+        if let v = settings.smoothScaling { config["smoothScaling"] = v ? 1 : 0 }
+        if let v = settings.fixedAspectRatio { config["fixedAspectRatio"] = v }
+        if let v = settings.frameSkip { config["frameSkip"] = v }
+        if let v = settings.fontScale { config["fontScale"] = v }
+        config.removeValue(forKey: "vsync")
+        if let v = settings.vsync { config["syncToRefreshrate"] = v }
+        if let v = settings.pathCache { config["pathCache"] = v }
+
+        config.removeValue(forKey: "defScreenW")
+        config.removeValue(forKey: "defScreenH")
+        if let scale = settings.renderScale {
+            if scale.enableHires {
+                config["enableHires"] = true
+                config["framebufferScalingFactor"] = scale.framebufferScalingFactor
+            } else {
+                config["enableHires"] = false
+                config.removeValue(forKey: "framebufferScalingFactor")
+            }
+        }
+
+        if let v = settings.solidFonts {
+            config["solidFonts"] = v ? ["*"] : [] as [String]
+        }
+
+        if let data = try? JSONSerialization.data(
+            withJSONObject: config, options: [.prettyPrinted, .sortedKeys]),
+            let jsonString = String(data: data, encoding: .utf8)
+        {
+            try? jsonString.write(to: configURL, atomically: true, encoding: .utf8)
+        }
+    }
+
+    private static func parseJSONWithComments(_ raw: String) -> [String: Any]? {
+        JSON5LiteParser.parseObject(raw)
+    }
+}

--- a/ios/Empo/src/Library/GameContainer.swift
+++ b/ios/Empo/src/Library/GameContainer.swift
@@ -276,8 +276,43 @@ struct GameContainer: Equatable, Hashable {
     /// `rm -rf` removes Game/, EmpoState/, Logs/, Metadata/ - and
     /// thus all per-game saves, settings, logs, custom artwork,
     /// crash markers - in a single call.
+    ///
+    /// Archives and folder imports can land with read-only POSIX
+    /// bits on `Game/` (common in Windows-origin zips). iOS refuses
+    /// to unlink children through a non-writable directory, so we
+    /// normalize owner-write permission on the tree first.
     func deleteAll() throws {
-        try FileManager.default.removeItem(at: url)
+        let fm = FileManager.default
+        try Self.makeTreeDeletable(at: url, fm: fm)
+        try fm.removeItem(at: url)
+    }
+
+    /// Ensure every path under `url` is deletable by the app
+    /// sandbox. Only touches owner-write; leaves group/other as-is.
+    private static func makeTreeDeletable(at url: URL, fm: FileManager) throws {
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: url.path, isDirectory: &isDir) else { return }
+
+        if isDir.boolValue {
+            let children = try fm.contentsOfDirectory(at: url, includingPropertiesForKeys: nil)
+            for child in children {
+                try makeTreeDeletable(at: child, fm: fm)
+            }
+            try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        } else {
+            try fm.setAttributes([.posixPermissions: 0o644], ofItemAtPath: url.path)
+        }
+    }
+
+    /// Imported game trees sometimes arrive with a read-only `Game/`
+    /// root (archive metadata or macOS copyItem). Empo never needs
+    /// that for immutability - file content stays untouched; we just
+    /// need owner-write so a future delete can recurse.
+    static func normalizeImportedGamePermissions(at gameURL: URL) {
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: gameURL.path
+        )
     }
 
     // MARK: - Slug helper

--- a/ios/Empo/src/Library/GameLibrary.swift
+++ b/ios/Empo/src/Library/GameLibrary.swift
@@ -149,6 +149,43 @@ class GameLibrary {
         withAnimation { games[idx] = entry }
     }
 
+    /// Filtered + sorted catalog for the library grid/list. Reads
+    /// `games` so SwiftUI Observation tracks reloads.
+    func displayedCatalog(
+        search: String,
+        sort: LibrarySortOption,
+        sizes: [String: Int64]
+    ) -> [GameEntry] {
+        let base =
+            search.isEmpty
+            ? games
+            : games.filter { $0.title.localizedCaseInsensitiveContains(search) }
+        return sort.sort(base, sizes: sizes)
+    }
+
+    /// Pre-flight import placeholders shown above the catalog when
+    /// the library already has games.
+    func pendingValidationCatalog() -> [GameEntry] {
+        guard !games.isEmpty else { return [] }
+        return pendingImports.values
+            .sorted { $0.order < $1.order }
+            .map(\.syntheticEntry)
+    }
+
+    /// Hero card candidate for "Continue playing", or nil.
+    func recentlyPlayedCandidate(
+        showContinuePlaying: Bool,
+        searchText: String
+    ) -> GameEntry? {
+        guard showContinuePlaying, searchText.isEmpty else { return nil }
+        let readyGames = games.filter { $0.status == .ready }
+        guard readyGames.count > 1 else { return nil }
+        return
+            readyGames
+            .filter { $0.lastPlayed != nil }
+            .max(by: { ($0.lastPlayed ?? .distantPast) < ($1.lastPlayed ?? .distantPast) })
+    }
+
     func ensureGamesDirectory() {
         if !fm.fileExists(atPath: GameContainer.rootURL.path) {
             try? fm.createDirectory(at: GameContainer.rootURL, withIntermediateDirectories: true)

--- a/ios/Empo/src/Library/GameLibraryView.swift
+++ b/ios/Empo/src/Library/GameLibraryView.swift
@@ -69,11 +69,15 @@ struct GameLibraryView: View {
     // is cheap; .map(\.id) in `.animation(value:)` was the actual
     // hot-loop offender and was dropped.
     private var filteredGames: [GameEntry] {
-        let base =
-            searchText.isEmpty
-            ? library.games
-            : library.games.filter { $0.title.localizedCaseInsensitiveContains(searchText) }
-        return settings.librarySortOption.sort(base, sizes: gameSizes)
+        library.displayedCatalog(
+            search: searchText,
+            sort: settings.librarySortOption,
+            sizes: gameSizes
+        )
+    }
+
+    private var catalogAnimationKey: [String] {
+        filteredGames.map { "\($0.id):\($0.status.phase)" }
     }
 
     /// Synthetic cards for pre-flight validations, pinned to the top
@@ -82,10 +86,7 @@ struct GameLibraryView: View {
     /// feedback on the Import button so the empty state doesn't
     /// bounce in and out on invalid imports.
     private var pendingValidationEntries: [GameEntry] {
-        guard !library.games.isEmpty else { return [] }
-        return library.pendingImports.values
-            .sorted { $0.order < $1.order }
-            .map(\.syntheticEntry)
+        library.pendingValidationCatalog()
     }
 
     private var showEmpty: Bool {
@@ -93,15 +94,10 @@ struct GameLibraryView: View {
     }
 
     private var recentlyPlayed: GameEntry? {
-        guard settings.showContinuePlaying else { return nil }
-        guard searchText.isEmpty else { return nil }
-        let readyGames = library.games.filter { $0.status == .ready }
-        guard readyGames.count > 1 else { return nil }  // no hero if only 1 game
-
-        return
-            readyGames
-            .filter { $0.lastPlayed != nil }
-            .max(by: { ($0.lastPlayed ?? .distantPast) < ($1.lastPlayed ?? .distantPast) })
+        library.recentlyPlayedCandidate(
+            showContinuePlaying: settings.showContinuePlaying,
+            searchText: searchText
+        )
     }
 
     @Environment(\.verticalSizeClass) private var verticalSizeClass
@@ -438,8 +434,8 @@ struct GameLibraryView: View {
         .padding(.horizontal)
         .padding(.top, Spacing.lg)
         .padding(.bottom)
-        .animation(Motion.standard, value: filteredGames)
-        .animation(Motion.standard, value: pendingValidationEntries)
+        .animation(Motion.standard, value: catalogAnimationKey)
+        .animation(Motion.standard, value: pendingValidationEntries.map(\.id))
     }
 
     private func heroCard(for game: GameEntry) -> some View {
@@ -529,8 +525,8 @@ struct GameLibraryView: View {
         }
         .padding(.horizontal)
         .padding(.top, Spacing.lg)
-        .animation(Motion.standard, value: filteredGames)
-        .animation(Motion.standard, value: pendingValidationEntries)
+        .animation(Motion.standard, value: catalogAnimationKey)
+        .animation(Motion.standard, value: pendingValidationEntries.map(\.id))
     }
 
     @ViewBuilder

--- a/ios/Empo/src/Library/GameLibraryView.swift
+++ b/ios/Empo/src/Library/GameLibraryView.swift
@@ -66,8 +66,9 @@ struct GameLibraryView: View {
     // entries stuck around after reload (an imported game stayed in
     // the progress state forever). Keeping it computed means it
     // tracks library.games directly. Filter + sort on 10s of entries
-    // is cheap; .map(\.id) in `.animation(value:)` was the actual
-    // hot-loop offender and was dropped.
+    // is cheap; animating on full `[GameEntry]` arrays (and their
+    // associated values like import progress) was the hot-loop
+    // offender. Lightweight id/phase keys replace those triggers.
     private var filteredGames: [GameEntry] {
         library.displayedCatalog(
             search: searchText,

--- a/ios/Empo/src/Library/GameSettings.swift
+++ b/ios/Empo/src/Library/GameSettings.swift
@@ -229,7 +229,6 @@ struct GameSettings: Codable, Equatable {
     @Setting<Bool?, RuntimeFlag> var useInGameKeyboard: Bool?
 
     private static let settingsFilename = "game_settings.json"
-    private static let configFilename = "mkxp.json"
 
     /// Read the game's settings sidecar from `<container>/EmpoState/`
     /// (NOT the imported `Game/` subdir; settings live outside the
@@ -365,95 +364,6 @@ struct GameSettings: Codable, Equatable {
         GameScriptProfile.analyze(gameDirectory: gameDirectory).modernRubyScripts
     }
 
-    /// Best-effort "is this a Pokemon Essentials fangame?" detector.
-    /// Used to set the default for `useInGameKeyboard` so PE games
-    /// surface their built-in keyboard scene by default (PE 16-18
-    /// era games don't handle the iOS soft-keyboard backspace path
-    /// cleanly without our `pokemon_input.rb` shim, and the in-game
-    /// scene's keyboard navigation is the more natural UX for
-    /// those games anyway).
-    ///
-    /// Three signals, ANY-of. All require PE's actual code, data,
-    /// or runtime presence so non-PE games can't false-positive
-    /// just because they're Pokemon-themed (we deliberately do NOT
-    /// title-match on "pokemon" / "poké" / "pokémon" since plenty
-    /// of games reference the franchise by name without using PE
-    /// under the hood):
-    ///
-    ///   1. Runtime marker `<stateDir>/.pokemon_essentials_detected`
-    ///      written by `pokemon_input.rb` on a previous launch
-    ///      when `$PokemonSystem` was defined. Catches PE games
-    ///      whose scripts live inside an rgssad-encrypted archive
-    ///      where signals 2 and 3 below can't see plaintext PE
-    ///      identifiers. First launch falls through to signals 2/3
-    ///      (and may default to OFF if those also miss); every
-    ///      subsequent launch reads the marker and defaults ON.
-    ///
-    ///   2. `Data/Scripts.rxdata|rvdata|rvdata2` byte-contains a
-    ///      PE script-name signature (`PokeBattle_*`,
-    ///      `PokemonSystem`, `PokemonEntry`, `Compiler_PBS`).
-    ///      Script names live in the marshaled rxdata array as
-    ///      plain ASCII bytes - the source bodies are zlib-
-    ///      compressed but the names aren't, so a raw byte search
-    ///      works without a marshal decoder. Catches PE forks that
-    ///      ship scripts in plaintext rxdata (Vinemon, Edelweiss
-    ///      Chronicles, etc.).
-    ///
-    ///   3. `Data/` contains PE-style compiled PBS data shards
-    ///      (`abilities.dat`, `species.dat`, `moves.dat`, etc.).
-    ///      PE 19+ ships compiled PBS as `*.dat` files alongside
-    ///      the rxdata; vanilla RGSS games don't ship these
-    ///      specific filenames. Catches newer PE forks where the
-    ///      scripts file is a small ScriptLoader stub and the bulk
-    ///      of code lives in external `Data/Scripts/*.rb`.
-    static func detectPokemonEssentials(
-        in gameDirectory: URL,
-        stateDirectory: URL
-    ) -> Bool {
-        let fm = FileManager.default
-
-        // Signal 1: runtime-detection marker from a prior launch.
-        let marker =
-            stateDirectory
-            .appendingPathComponent(".pokemon_essentials_detected")
-        if fm.fileExists(atPath: marker.path) { return true }
-
-        // Signal 2: Scripts.rxdata byte-grep for PE script names.
-        let scriptCandidates = [
-            "Data/Scripts.rxdata",
-            "Data/Scripts.rvdata",
-            "Data/Scripts.rvdata2",
-        ]
-        let scriptSignatures: [Data] = [
-            Data("PokeBattle".utf8),
-            Data("PokemonSystem".utf8),
-            Data("PokemonEntry".utf8),
-            Data("Compiler_PBS".utf8),
-        ]
-        for relPath in scriptCandidates {
-            let url = gameDirectory.appendingPathComponent(relPath)
-            guard let data = try? Data(contentsOf: url), data.count > 1024
-            else { continue }
-            for sig in scriptSignatures where data.range(of: sig) != nil {
-                return true
-            }
-        }
-
-        // Signal 3: PE-style compiled PBS data files.
-        let dataDir = gameDirectory.appendingPathComponent("Data")
-        let peDataMarkers = [
-            "abilities.dat", "species.dat", "moves.dat",
-            "pokemon.dat", "pokemon_forms.dat", "items.dat",
-            "trainer_types.dat", "encounters.dat",
-        ]
-        for marker in peDataMarkers {
-            let url = dataDir.appendingPathComponent(marker)
-            if fm.fileExists(atPath: url.path) { return true }
-        }
-
-        return false
-    }
-
     /// Resolve the engine's `syntaxTransform` mode for this game.
     /// Honors an explicit `useModernRuby` setting; runs the .rb
     /// scanner when the setting is nil ("auto").
@@ -497,153 +407,19 @@ struct GameSettings: Codable, Equatable {
     /// merged back. That makes `Game/mkxp.json` the developer's
     /// source-of-truth for the per-game-defaults UI.
     static func readGameDefaults(from gameDirectory: URL) -> GameConfigDefaults {
-        let sourceURL = gameDirectory.appendingPathComponent(configFilename)
-
-        guard let raw = try? String(contentsOf: sourceURL, encoding: .utf8),
-            let config = parseJSONWithComments(raw)
-        else {
-            return GameConfigDefaults()
-        }
-
-        // Read render scale from enableHires + framebufferScalingFactor.
-        // The legacy `defScreenW`/`defScreenH` keys are intentionally
-        // ignored: they only sized the SDL window (irrelevant on
-        // iOS) and never controlled the rendering buffer.
-        let enableHires = config["enableHires"] as? Bool ?? false
-        let scalingFactor =
-            (config["framebufferScalingFactor"] as? Double)
-            ?? (config["framebufferScalingFactor"] as? Int).map(Double.init)
-            ?? 1.0
-        let renderScale: RenderScale? =
-            if enableHires {
-                // Snap to the nearest supported step. Engine accepts
-                // arbitrary doubles, but the UI only exposes 1/2/4 - so
-                // a developer-shipped 3.0 reads back as "High (2x)" in
-                // the defaults row.
-                switch scalingFactor {
-                case ..<1.5: RenderScale.x1
-                case ..<3.0: RenderScale.x2
-                default: RenderScale.x4
-                }
-            } else {
-                nil
-            }
-
-        // solidFonts is an array of font names in mkxp.json; treat non-empty as "enabled"
-        let solidFontsArray = config["solidFonts"] as? [String]
-        let solidFontsEnabled: Bool? = solidFontsArray.map { !$0.isEmpty }
-
-        return GameConfigDefaults(
-            smoothScaling: (config["smoothScaling"] as? Int).map { $0 != 0 },
-            fixedAspectRatio: config["fixedAspectRatio"] as? Bool,
-            renderScale: renderScale,
-            frameSkip: config["frameSkip"] as? Bool,
-            // mkxp-z controls vsync via
-            // `syncToRefreshrate`. The legacy `vsync` field exists in
-            // the parsed Config struct but is read by no rendering
-            // code, so writing it has no effect. Read both for
-            // backward-compat with hand-authored configs that used
-            // the old key, but prefer `syncToRefreshrate`.
-            vsync: (config["syncToRefreshrate"] as? Bool)
-                ?? (config["vsync"] as? Bool),
-            pathCache: config["pathCache"] as? Bool,
-            fontScale: config["fontScale"] as? Double,
-            solidFonts: solidFontsEnabled
-        )
+        EngineConfigProjector.readGameDefaults(from: gameDirectory)
     }
 
-    /// Generate the game's managed mkxp.json (in
-    /// `<container>/EmpoState/`) by merging the developer's
-    /// untouched `Game/mkxp.json` (if present) with these settings.
-    ///
-    /// `stateDirectory` is the per-game state directory (where the
-    /// merged mkxp.json is written). `gameDirectory` is the
-    /// imported `<container>/Game/` folder, which Empo treats as
-    /// immutable after import; so reading the developer's source
-    /// directly from `gameDirectory/mkxp.json` is safe and removes
-    /// the need for the historic `mkxp.original.json` snapshot.
     func applyToConfig(stateDirectory: URL, gameDirectory: URL) {
-        let configURL = stateDirectory.appendingPathComponent(Self.configFilename)
-        let sourceURL = gameDirectory.appendingPathComponent(Self.configFilename)
-
-        var config: [String: Any] = [:]
-        if FileManager.default.fileExists(atPath: sourceURL.path),
-            let raw = try? String(contentsOf: sourceURL, encoding: .utf8),
-            let parsed = Self.parseJSONWithComments(raw)
-        {
-            config = parsed
-        }
-
-        // Host-managed keys travel via engine bridges, NOT through
-        // mkxp.json:
-        //   - syntaxTransform: mkxp_setSyntaxTransformMode
-        //   - fast-forward: mkxp_setFastForwardMultiplier
-        // Strip any leftovers in the developer's source so the
-        // merged config stays a clean mirror of host overrides on
-        // top of developer intent.
-        config.removeValue(forKey: "syntaxTransform")
-
-        if let v = smoothScaling { config["smoothScaling"] = v ? 1 : 0 }
-        if let v = fixedAspectRatio { config["fixedAspectRatio"] = v }
-        if let v = frameSkip { config["frameSkip"] = v }
-        if let v = fontScale { config["fontScale"] = v }
-        // mkxp-z's vsync is gated by `syncToRefreshrate`, not the
-        // dead `vsync` field. Strip the legacy key so the merged
-        // config doesn't carry unused state.
-        config.removeValue(forKey: "vsync")
-        if let v = vsync { config["syncToRefreshrate"] = v }
-        if let v = pathCache { config["pathCache"] = v }
-
-        // Render scale: mapped to mkxp-z's `enableHires` +
-        // `framebufferScalingFactor`. The legacy `defScreenW`/
-        // `defScreenH` keys are stripped from the merged config so
-        // existing imports lose the dead state on next save - those
-        // only sized the SDL window (irrelevant on iOS, which is
-        // always fullscreen) and never controlled the rendering
-        // buffer.
-        config.removeValue(forKey: "defScreenW")
-        config.removeValue(forKey: "defScreenH")
-        if let scale = renderScale {
-            if scale.enableHires {
-                config["enableHires"] = true
-                config["framebufferScalingFactor"] = scale.framebufferScalingFactor
-            } else {
-                // x1 - explicitly disable hires so a developer's
-                // `enableHires=true` from Game/mkxp.json doesn't
-                // leak into the merged config when the user picks
-                // "Default".
-                config["enableHires"] = false
-                config.removeValue(forKey: "framebufferScalingFactor")
-            }
-        }
-
-        // Solid fonts: mkxp.json expects an array of font names.
-        // When enabled via toggle, apply to all fonts with a wildcard entry.
-        if let v = solidFonts {
-            config["solidFonts"] = v ? ["*"] : [] as [String]
-        }
-
-        // speedMultiplier is now runtime-only (PlayerMoreSheet's
-        // Fast forward toggle calls mkxp_setFastForwardMultiplier).
-        // Game launches at default speed; the user opts in via the
-        // in-game menu. Nothing to write here.
-
-        if let data = try? JSONSerialization.data(
-            withJSONObject: config, options: [.prettyPrinted, .sortedKeys]),
-            let jsonString = String(data: data, encoding: .utf8)
-        {
-            try? jsonString.write(to: configURL, atomically: true, encoding: .utf8)
-        }
+        EngineConfigProjector.apply(
+            settings: self,
+            stateDirectory: stateDirectory,
+            gameDirectory: gameDirectory
+        )
     }
 
     var hasCustomizations: Bool {
         self != GameSettings()
-    }
-
-    /// Parses mkxp.json (which can have `//` comments). Thin
-    /// wrapper around `JSON5LiteParser` kept for call-site brevity.
-    static func parseJSONWithComments(_ raw: String) -> [String: Any]? {
-        JSON5LiteParser.parseObject(raw)
     }
 }
 

--- a/ios/Empo/src/Library/GameSettingsView.swift
+++ b/ios/Empo/src/Library/GameSettingsView.swift
@@ -136,7 +136,7 @@ struct GameSettingsView: View {
         _settings = State(initialValue: s)
         _defaults = State(initialValue: defs)
         self.initialSettings = s
-        self.isPokemonEssentialsDefault = GameSettings.detectPokemonEssentials(
+        self.isPokemonEssentialsDefault = PokemonEssentialsDetection.detect(
             in: dir, stateDirectory: stateDir
         )
     }

--- a/ios/Empo/src/Library/ImportPipeline.swift
+++ b/ios/Empo/src/Library/ImportPipeline.swift
@@ -754,6 +754,7 @@ extension GameLibrary {
 
         try fm.createDirectory(at: container.url, withIntermediateDirectories: true)
         try fm.moveItem(at: gameRoot, to: container.gameURL)
+        GameContainer.normalizeImportedGamePermissions(at: container.gameURL)
 
         if isImportCancelled(importID) { throw ImportCancelled() }
 
@@ -941,6 +942,7 @@ extension GameLibrary {
         // unchanged because Metadata/ is a sibling of Game/.
         try fm.createDirectory(at: container.url, withIntermediateDirectories: true)
         try fm.moveItem(at: gameRoot, to: container.gameURL)
+        GameContainer.normalizeImportedGamePermissions(at: container.gameURL)
 
         if isImportCancelled(importID) { throw ImportCancelled() }
         if let bundle = jgpBundle {

--- a/ios/Empo/src/Library/ImportPipeline.swift
+++ b/ios/Empo/src/Library/ImportPipeline.swift
@@ -265,10 +265,14 @@ final class ImportPipeline {
             if accessing { url.stopAccessingSecurityScopedResource() }
 
             if let error {
-                self.presentError(
-                    title: "Couldn't import \(quoted(archiveName))",
-                    message: error.localizedDescription
-                )
+                if error is GameLibrary.ImportCancelled {
+                    // User cancelled; finish cleanup without surfacing UI.
+                } else {
+                    self.presentError(
+                        title: "Couldn't import \(quoted(archiveName))",
+                        message: error.localizedDescription
+                    )
+                }
             } else {
                 Haptics.impact()
             }
@@ -573,6 +577,7 @@ extension GameLibrary {
                 NSLog("[GameLibrary] Import cancelled: %@", importID)
                 await MainActor.run {
                     GameLibrary.shared.abandonImport(importID: importID, container: nil)
+                    completion(ImportCancelled())
                 }
             } catch {
                 markNotInFlight()

--- a/ios/Empo/src/Library/PokemonEssentialsDetection.swift
+++ b/ios/Empo/src/Library/PokemonEssentialsDetection.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Best-effort "is this a Pokemon Essentials fangame?" detector.
+enum PokemonEssentialsDetection {
+    static func detect(
+        in gameDirectory: URL,
+        stateDirectory: URL
+    ) -> Bool {
+        let fm = FileManager.default
+
+        let marker =
+            stateDirectory
+            .appendingPathComponent(".pokemon_essentials_detected")
+        if fm.fileExists(atPath: marker.path) { return true }
+
+        let scriptCandidates = [
+            "Data/Scripts.rxdata",
+            "Data/Scripts.rvdata",
+            "Data/Scripts.rvdata2",
+        ]
+        let scriptSignatures: [Data] = [
+            Data("PokeBattle".utf8),
+            Data("PokemonSystem".utf8),
+            Data("PokemonEntry".utf8),
+            Data("Compiler_PBS".utf8),
+        ]
+        for relPath in scriptCandidates {
+            let url = gameDirectory.appendingPathComponent(relPath)
+            guard let data = try? Data(contentsOf: url), data.count > 1024
+            else { continue }
+            for sig in scriptSignatures where data.range(of: sig) != nil {
+                return true
+            }
+        }
+
+        let dataDir = gameDirectory.appendingPathComponent("Data")
+        let peDataMarkers = [
+            "abilities.dat", "species.dat", "moves.dat",
+            "pokemon.dat", "pokemon_forms.dat", "items.dat",
+            "trainer_types.dat", "encounters.dat",
+        ]
+        for marker in peDataMarkers {
+            let url = dataDir.appendingPathComponent(marker)
+            if fm.fileExists(atPath: url.path) { return true }
+        }
+
+        return false
+    }
+}

--- a/ios/Empo/src/Player/GameControls.swift
+++ b/ios/Empo/src/Player/GameControls.swift
@@ -4,8 +4,8 @@ import SwiftUI
 // Liquid Glass material.
 //
 // Touch-dispatch semantics:
-//   - `mkxp_injectKeyEvent(scancode, 1)` on press-down,
-//     `mkxp_injectKeyEvent(scancode, 0)` on release.
+//   - `EngineSessionCoordinator.shared.injectKey(scancode:, pressed:)`
+//     on press-down and release.
 //   - Action button: slide-off does NOT release the key.
 //   - D-pad: 8-wedge angular mapping, bitwise diff across moves,
 //     inner 20% dead zone, slide-off at radius+30pt releases all
@@ -19,7 +19,7 @@ import SwiftUI
 // MARK: - Action button
 
 /// Circular glass button. Presses emit a down/up event pair through
-/// `mkxp_injectKeyEvent`. Holding and sliding the finger off the
+/// `EngineSessionCoordinator`. Holding and sliding the finger off the
 /// button does NOT release the key.
 struct ActionButton: View {
     let label: String
@@ -89,7 +89,7 @@ struct ActionButton: View {
                 if !isPressed {
                     isPressed = true
                     Haptics.controllerTap()
-                    mkxp_injectKeyEvent(scancode, 1)
+                    EngineSessionCoordinator.shared.injectKey(scancode: scancode, pressed: true)
                 }
             }
             .onEnded { _ in
@@ -100,7 +100,7 @@ struct ActionButton: View {
     private func releaseIfHeld() {
         guard isPressed else { return }
         isPressed = false
-        mkxp_injectKeyEvent(scancode, 0)
+        EngineSessionCoordinator.shared.injectKey(scancode: scancode, pressed: false)
     }
 }
 
@@ -311,8 +311,8 @@ struct DPad: View {
         if newSet == activeDirections { return }
         let toRelease = activeDirections.subtracting(newSet)
         let toPress = newSet.subtracting(activeDirections)
-        toRelease.forEach { mkxp_injectKeyEvent($0.scancode, 0) }
-        toPress.forEach { mkxp_injectKeyEvent($0.scancode, 1) }
+        toRelease.forEach { EngineSessionCoordinator.shared.injectKey(scancode: $0.scancode, pressed: false) }
+        toPress.forEach { EngineSessionCoordinator.shared.injectKey(scancode: $0.scancode, pressed: true) }
         if !toPress.isEmpty {
             Haptics.controllerTap()
         }
@@ -320,7 +320,9 @@ struct DPad: View {
     }
 
     private func releaseAll() {
-        activeDirections.forEach { mkxp_injectKeyEvent($0.scancode, 0) }
+        activeDirections.forEach {
+            EngineSessionCoordinator.shared.injectKey(scancode: $0.scancode, pressed: false)
+        }
         activeDirections = []
     }
 }

--- a/ios/Empo/src/Player/KeyboardFieldRepresentable.swift
+++ b/ios/Empo/src/Player/KeyboardFieldRepresentable.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// Invisible UIKit text field used exclusively to bring up the
 /// system keyboard and route its text and return-key events into
-/// the engine via `mkxp_injectKeyEvent`. The visible on-screen
+/// the engine via `EngineSessionCoordinator`. The visible on-screen
 /// controls (D-pad, action buttons) are plain SwiftUI now - see
 /// `GameControls.swift` - so this is the only UIViewRepresentable
 /// the player still needs.
@@ -49,11 +49,7 @@ struct KeyboardFieldRepresentable: UIViewRepresentable {
             // stays enabled), so the empty-replacement case has to be
             // translated into a scancode injection explicitly.
             if string.isEmpty && range.length > 0 {
-                mkxp_injectKeyEvent(Int32(MKXP_SCANCODE_BACKSPACE), 1)
-                Task { @MainActor in
-                    try? await Task.sleep(for: .milliseconds(50))
-                    mkxp_injectKeyEvent(Int32(MKXP_SCANCODE_BACKSPACE), 0)
-                }
+                EngineSessionCoordinator.shared.injectKeyTap(scancode: Int32(MKXP_SCANCODE_BACKSPACE))
                 textField.text = " "
                 return false
             }
@@ -93,14 +89,20 @@ struct KeyboardFieldRepresentable: UIViewRepresentable {
                 let sc = scancodeForSwiftCharacter(c)
                 if sc == MKXP_SCANCODE_UNKNOWN { continue }
 
-                if isUpper { mkxp_injectKeyEvent(Int32(MKXP_SCANCODE_LSHIFT), 1) }
-                mkxp_injectKeyEvent(sc, 1)
+                if isUpper {
+                    EngineSessionCoordinator.shared.injectKey(
+                        scancode: Int32(MKXP_SCANCODE_LSHIFT), pressed: true)
+                }
+                EngineSessionCoordinator.shared.injectKey(scancode: sc, pressed: true)
                 let scancode = sc
                 let upper = isUpper
                 Task { @MainActor in
                     try? await Task.sleep(for: .milliseconds(50))
-                    mkxp_injectKeyEvent(scancode, 0)
-                    if upper { mkxp_injectKeyEvent(Int32(MKXP_SCANCODE_LSHIFT), 0) }
+                    EngineSessionCoordinator.shared.injectKey(scancode: scancode, pressed: false)
+                    if upper {
+                        EngineSessionCoordinator.shared.injectKey(
+                            scancode: Int32(MKXP_SCANCODE_LSHIFT), pressed: false)
+                    }
                 }
             }
             textField.text = " "
@@ -108,11 +110,7 @@ struct KeyboardFieldRepresentable: UIViewRepresentable {
         }
 
         func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-            mkxp_injectKeyEvent(Int32(MKXP_SCANCODE_RETURN), 1)
-            Task { @MainActor in
-                try? await Task.sleep(for: .milliseconds(50))
-                mkxp_injectKeyEvent(Int32(MKXP_SCANCODE_RETURN), 0)
-            }
+            EngineSessionCoordinator.shared.injectKeyTap(scancode: Int32(MKXP_SCANCODE_RETURN))
             return false
         }
 

--- a/ios/Empo/src/Player/PlayerView.swift
+++ b/ios/Empo/src/Player/PlayerView.swift
@@ -172,29 +172,18 @@ struct PlayerView: View {
             }
         }
         .ignoresSafeArea()
-        .onReceive(
-            NotificationCenter.default.publisher(for: NSNotification.Name(rawValue: "TCTextInputMode"))
-        ) { note in
-            // Engine fired SDL_StartTextInput / SDL_StopTextInput
-            // because the game asked for text input via
-            // `Input.text_input = true/false`. Auto-flip the
-            // keyboard mode so the soft keyboard appears (or
-            // dismisses) without user action.
-            //
-            // No-op if the user already has the keyboard open via
-            // the toolbar toggle - the keyboardMode state is just
-            // re-set to the same value.
-            let active = (note.userInfo?["active"] as? Bool) ?? false
-            if active != keyboardMode {
-                keyboardMode = active
-                if active {
-                    AppWindow.setAllowKeyWindow(true)
+        .onAppear {
+            // Engine fired SDL_StartTextInput / SDL_StopTextInput when
+            // the game toggles `Input.text_input`. Auto-flip keyboard
+            // mode so the soft keyboard appears without user action.
+            EngineSessionCoordinator.shared.setTextInputModeHandler { active in
+                if active != keyboardMode {
+                    keyboardMode = active
+                    if active {
+                        AppWindow.setAllowKeyWindow(true)
+                    }
                 }
             }
-        }
-        .onAppear {
-            TCInstallKeyEventWatcher()
-            TCInstallTextInputModeWatcher()
 
             // Load the per-game fast-forward multiplier (and re-push
             // to the engine if the toggle was already on). Fires on
@@ -221,6 +210,9 @@ struct PlayerView: View {
                     startSnapshotFade()
                 }
             }
+        }
+        .onDisappear {
+            EngineSessionCoordinator.shared.clearTextInputModeHandler()
         }
         .onChange(of: pauseManager.snapshotCanFade) { _, canFade in
             if canFade && resumeSnapshot != nil {
@@ -384,10 +376,8 @@ struct PlayerView: View {
             // the KEYDOWN. Otherwise both events get consumed in the
             // same eventthread batch and Input.update never observes
             // the pressed-edge the Scene_Map hook is waiting for.
-            mkxp_injectKeyEvent(Int32(MKXP_SCANCODE_HOME), 1)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                mkxp_injectKeyEvent(Int32(MKXP_SCANCODE_HOME), 0)
-            }
+            EngineSessionCoordinator.shared.injectKeyTap(
+                scancode: Int32(MKXP_SCANCODE_HOME), holdMilliseconds: 100)
         }
     }
 

--- a/ios/Empo/src/Player/TouchControls.h
+++ b/ios/Empo/src/Player/TouchControls.h
@@ -4,8 +4,7 @@
 // TCDPadView (on-screen directional pad). Both have been replaced by
 // SwiftUI + Liquid Glass equivalents in GameControls.swift; what's
 // left here is the invisible keyboard field that UIKit has to own
-// (for system-keyboard IME and scancode injection on key events) and
-// the hardware-keyboard event watcher installed from PlayerView.
+// (for system-keyboard IME and scancode injection on key events).
 
 #import <UIKit/UIKit.h>
 
@@ -22,17 +21,6 @@ extern "C" {
 #endif
 
 UIView *TCCreateKeyboardAccessoryView(void);
-
-extern NSString *const TCKeyEventNotification;
-
-// Posted from the engine bridge when SDL text-input mode flips
-// (game called `Input.text_input = true` or `false`). userInfo
-// has `@"active"` -> NSNumber<BOOL>. PlayerView listens and
-// auto-shows / hides the soft keyboard.
-extern NSString *const TCTextInputModeNotification;
-
-void TCInstallKeyEventWatcher(void);
-void TCInstallTextInputModeWatcher(void);
 
 #ifdef __cplusplus
 }

--- a/ios/Empo/src/Player/TouchControls.mm
+++ b/ios/Empo/src/Player/TouchControls.mm
@@ -18,52 +18,6 @@ static void injectKey(int scancode, BOOL pressed) {
     mkxp_injectKeyEvent(scancode, pressed ? 1 : 0);
 }
 
-NSString *const TCKeyEventNotification = @"TCKeyEvent";
-
-static void keyEventBridgeCallback(int scancode, int pressed, void * /*userdata*/) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [[NSNotificationCenter defaultCenter] postNotificationName:TCKeyEventNotification
-                                                            object:nil
-                                                          userInfo:@{
-                                                              @"scancode" : @(scancode),
-                                                              @"pressed" : @(pressed),
-                                                          }];
-    });
-}
-
-static BOOL g_keyWatcherInstalled = NO;
-void TCInstallKeyEventWatcher(void) {
-    if (!g_keyWatcherInstalled) {
-        mkxp_setKeyEventCallback(keyEventBridgeCallback, NULL);
-        g_keyWatcherInstalled = YES;
-    }
-}
-
-NSString *const TCTextInputModeNotification = @"TCTextInputMode";
-
-// Engine fires this from EventThread (main thread) when
-// SDL_StartTextInput / SDL_StopTextInput is dispatched. We bounce
-// onto the main queue (no-op if already there) so SwiftUI can
-// safely react via NotificationCenter.publisher.
-static void textInputModeBridgeCallback(int active, void * /*userdata*/) {
-    BOOL on = active ? YES : NO;
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [[NSNotificationCenter defaultCenter] postNotificationName:TCTextInputModeNotification
-                                                            object:nil
-                                                          userInfo:@{
-                                                              @"active" : @(on)
-                                                          }];
-    });
-}
-
-static BOOL g_textInputWatcherInstalled = NO;
-void TCInstallTextInputModeWatcher(void) {
-    if (!g_textInputWatcherInstalled) {
-        mkxp_setTextInputModeCallback(textInputModeBridgeCallback, NULL);
-        g_textInputWatcherInstalled = YES;
-    }
-}
-
 // Character-to-scancode mapping (for system keyboard)
 
 static int scancodeForCharacter(unichar c) {


### PR DESCRIPTION
## Summary
- Add `injectKey`, `injectKeyTap`, and text-input-mode handler on `EngineSessionCoordinator`
- Route SwiftUI controls and soft-keyboard input through the coordinator instead of calling `mkxp_injectKeyEvent` directly
- Remove `NotificationCenter` text-input bridge from `TouchControls.mm`; coordinator registers `mkxp_setTextInputModeCallback` directly

## Test plan
- [ ] On-screen D-pad and action buttons work in-game
- [ ] Soft keyboard injects characters and backspace
- [ ] Game requesting `Input.text_input` auto-shows/hides keyboard
- [ ] Cheat menu HOME key tap still works
- [ ] Keyboard accessory bar (F-keys, arrows) still works